### PR TITLE
[UI/MD] ios统一音量键翻页开关统一系统Material Design 3 风格

### DIFF
--- a/lib/views/settings/enable_volume.dart
+++ b/lib/views/settings/enable_volume.dart
@@ -16,15 +16,16 @@ class _EnableVolumeState extends State<EnableVolume> {
   Widget build(BuildContext context) {
     return ListTile(
       title: const Text('音量键翻页'),
-      leading: Container(
-        padding: const EdgeInsets.all(6),
-        decoration: BoxDecoration(
-          color: context.colorScheme.primary.withValues(alpha: 0.1),
-          shape: BoxShape.circle,
+      leading: CircleAvatar(
+        radius: 17,
+        backgroundColor: context.colorScheme.primary.withOpacity(0.1),
+        child: Icon(
+          Icons.volume_down_outlined,
+          size: 22,
+          color: context.colorScheme.primary,
         ),
-        child: const Icon(Icons.volume_down_outlined, size: 22),
       ),
-      trailing: Switch.adaptive(
+      trailing: Switch(
         value: _enable,
         onChanged: (value) {
           setState(() {


### PR DESCRIPTION
4.  **UI样式统一：修复ios
![IMG_5289](https://github.com/user-attachments/assets/214e4c31-00b0-49e8-b1a8-d3534a27ea0f)
![IMG_5285](https://github.com/user-attachments/assets/d525311b-cc68-4308-be63-c8c3db5609a6)
设置项视觉割裂感**
    -   在 `lib/views/settings/enable_volume.dart` 中，将 `Switch.adaptive` 替换为标准的 `Switch` 组件，并简化了 `leading` 图标的样式，使其与应用的 Material Design 3 风格保持一致，解决了视觉上的不协调问题。