### PR TITLE
feat: add smooth scroll auto-flip mode for vertical reader

### DIFF
--- a/lib/config/app_config.dart
+++ b/lib/config/app_config.dart
@@ -86,6 +86,9 @@ class AppConf {
   /// 翻页间隔
   int _interval = 5;
 
+  /// 平滑滚动速度（每帧像素数）
+  double _scrollSpeed = 2.0;
+
   /// 是否需要身份认证
   bool _needAuth = false;
 
@@ -140,6 +143,8 @@ class AppConf {
     instance._windowWidth = prefsWithCache.getDouble('windowWidth');
     instance._windowHeight = prefsWithCache.getDouble('windowHeight');
     instance._interval = prefsWithCache.getInt('interval') ?? 5;
+    instance._scrollSpeed =
+        prefsWithCache.getDouble('scrollSpeed') ?? 2.0;
     instance._themeMode = prefsWithCache.getString('theme_mode') ?? 'System';
     instance._primaryColor =
         prefsWithCache.getString('primary_color') ?? 'System';
@@ -297,6 +302,11 @@ class AppConf {
     SharedPreferencesUtil.prefsWithCache.setInt('interval', value);
   }
 
+  set scrollSpeed(double value) {
+    _scrollSpeed = value;
+    SharedPreferencesUtil.prefsWithCache.setDouble('scrollSpeed', value);
+  }
+
   set themeMode(String value) {
     _themeMode = value;
     SharedPreferencesUtil.prefsWithCache.setString('theme_mode', value);
@@ -367,6 +377,7 @@ class AppConf {
   double? get windowHeight => _windowHeight;
 
   int get interval => _interval;
+  double get scrollSpeed => _scrollSpeed;
   String get themeMode => _themeMode;
   String get primaryColor => _primaryColor;
   List<String> get searchHistory => _searchHistory;

--- a/lib/views/reader/providers/reader_provider.dart
+++ b/lib/views/reader/providers/reader_provider.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:haka_comic/config/app_config.dart';
 import 'package:haka_comic/database/read_record_helper.dart';
@@ -89,10 +90,15 @@ class ReaderProvider extends RequestProvider {
         if (_isPageTurning) {
           turnPageTimer?.cancel();
           turnPageTimer = null;
+          _smoothTicker?.stop();
           _isPageTurnPausedByToolbar = true;
         }
       } else if (_isPageTurning && _isPageTurnPausedByToolbar) {
-        _startPageTurnTimer();
+        if (_isSmoothScroll) {
+          _smoothTicker?.start();
+        } else {
+          _startPageTurnTimer();
+        }
         _isPageTurnPausedByToolbar = false;
       }
 
@@ -303,8 +309,10 @@ class ReaderProvider extends RequestProvider {
     }
   }
 
-  /// 定时翻页
+  /// 自动翻页
   bool _isPageTurning = false;
+  bool _isSmoothScroll = false;
+  bool get isSmoothScroll => _isSmoothScroll;
   bool _isPageTurnPausedByToolbar = false;
   bool get isPageTurning => _isPageTurning;
   set isPageTurning(bool value) {
@@ -334,15 +342,56 @@ class ReaderProvider extends RequestProvider {
 
   /// 开始定时翻页
   void startPageTurn() {
+    _isSmoothScroll = false;
     _isPageTurnPausedByToolbar = false;
     _startPageTurnTimer();
     isPageTurning = true;
   }
 
-  /// 关闭定时翻页
+  /// 平滑滚动 Ticker
+  Ticker? _smoothTicker;
+  double _scrollSpeed = AppConf().scrollSpeed;
+  double get scrollSpeed => _scrollSpeed;
+  set scrollSpeed(double value) {
+    _scrollSpeed = value;
+    AppConf().scrollSpeed = value;
+    notifyListeners();
+  }
+
+  void updateScrollSpeed(double speed) {
+    scrollSpeed = speed;
+  }
+
+  /// 开始平滑滚动
+  void startSmoothScroll(TickerProvider vsync) {
+    _isSmoothScroll = true;
+    _isPageTurnPausedByToolbar = false;
+    _smoothTicker?.dispose();
+    _smoothTicker = vsync.createTicker((_) {
+      if (handler.state case Loading()) return;
+      if (pageNo == images.length - 1) {
+        if (!isLastChapter) {
+          goNext();
+        } else {
+          stopPageTurn();
+          Toast.show(message: '没有下一章了');
+        }
+        return;
+      }
+      scrollOffsetController.scrollTo(_scrollSpeed);
+    });
+    _smoothTicker!.start();
+    isPageTurning = true;
+  }
+
+  /// 关闭自动翻页（定时 & 平滑 通用）
   void stopPageTurn() {
     turnPageTimer?.cancel();
     turnPageTimer = null;
+    _smoothTicker?.stop();
+    _smoothTicker?.dispose();
+    _smoothTicker = null;
+    _isSmoothScroll = false;
     _isPageTurnPausedByToolbar = false;
     isPageTurning = false;
   }
@@ -382,6 +431,7 @@ class ReaderProvider extends RequestProvider {
   void dispose() {
     pageController.dispose();
     turnPageTimer?.cancel();
+    _smoothTicker?.dispose();
     preloadController.dispose();
     _pageNoTimer?.cancel();
     volumeController.stopListening();

--- a/lib/views/reader/widgets/bottom.dart
+++ b/lib/views/reader/widgets/bottom.dart
@@ -9,9 +9,15 @@ const kBottomBarHeight = 105.0;
 const kBottomBarBottom = 15.0;
 
 /// 底部工具栏
-class ReaderBottom extends StatelessWidget {
+class ReaderBottom extends StatefulWidget {
   const ReaderBottom({super.key});
 
+  @override
+  State<ReaderBottom> createState() => _ReaderBottomState();
+}
+
+class _ReaderBottomState extends State<ReaderBottom>
+    with SingleTickerProviderStateMixin {
   @override
   Widget build(BuildContext context) {
     final bottom = context.bottom;
@@ -134,6 +140,15 @@ class ReaderBottom extends StatelessWidget {
                 tooltip: '定时翻页',
                 icon: const Icon(Icons.timer_outlined),
               ),
+              if (context.selector((p) => p.readMode.isVertical))
+                IconButton(
+                  onPressed: () {
+                    context.reader.startSmoothScroll(this);
+                    context.reader.openOrCloseToolbar();
+                  },
+                  tooltip: '平滑滚动',
+                  icon: const Icon(Icons.keyboard_double_arrow_down),
+                ),
               IconButton(
                 onPressed: () {
                   context.stateReader.toggleLockMenu();
@@ -150,6 +165,13 @@ class ReaderBottom extends StatelessWidget {
   }
 
   Widget _buildPageTurnContent(BuildContext context) {
+    final isSmoothScroll = context.selector((p) => p.isSmoothScroll);
+    return isSmoothScroll
+        ? _buildSmoothScrollContent(context)
+        : _buildTimerContent(context);
+  }
+
+  Widget _buildTimerContent(BuildContext context) {
     final interval = context.selector((p) => p.interval);
     return Column(
       key: const ValueKey('page_turn_toolbar'),
@@ -180,6 +202,45 @@ class ReaderBottom extends StatelessWidget {
                   context.reader.openOrCloseToolbar();
                 },
                 child: const Text('关闭自动翻页'),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSmoothScrollContent(BuildContext context) {
+    final speed = context.selector((p) => p.scrollSpeed);
+    return Column(
+      key: const ValueKey('smooth_scroll_toolbar'),
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            const Text('速度'),
+            Expanded(
+              child: Slider(
+                value: speed,
+                min: 0.5,
+                max: 10.0,
+                divisions: 19,
+                onChanged: (v) => context.reader.updateScrollSpeed(v),
+              ),
+            ),
+            Text('${speed.toStringAsFixed(1)}px'),
+          ],
+        ),
+        Expanded(
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [
+              TextButton(
+                onPressed: () {
+                  context.reader.stopPageTurn();
+                  context.reader.openOrCloseToolbar();
+                },
+                child: const Text('关闭平滑滚动'),
               ),
             ],
           ),


### PR DESCRIPTION
## Description

  Add a new "smooth scroll" auto-flip mode for the vertical (webtoon) reader, alongside the existing timed page-flip mode. Users can
  now enable continuous conveyor-belt style scrolling with adjustable speed.

  Closes #104

  ## Reasoning

  The existing auto-flip feature only supported timed page-jumping (jump N×screen height every N seconds), which felt abrupt. This PR
   adds a `Ticker`-based smooth scrolling mode that calls `scrollOffsetController.scrollTo(speed)` every frame (~16ms), producing
  fluid continuous scrolling.

  Changes across 3 files:

  **`lib/config/app_config.dart`**
  - Added `scrollSpeed` config field (default `2.0` px/frame), persisted to SharedPreferences, following the existing `interval`
  pattern.

  **`lib/views/reader/providers/reader_provider.dart`**
  - Added `startSmoothScroll(TickerProvider vsync)`: creates a `Ticker` that scrolls by `_scrollSpeed` pixels each frame.
  - Boundary handling: when reaching the last image, automatically advances to the next chapter or stops with a toast if no next
  chapter exists.
  - `stopPageTurn()` now handles both Timer (timed mode) and Ticker (smooth mode) cleanup.
  - `openOrCloseToolbar()` pauses/resumes the Ticker when the toolbar opens/closes.
  - `dispose()` includes `_smoothTicker?.dispose()` for leak prevention.

  **`lib/views/reader/widgets/bottom.dart`**
  - `ReaderBottom` converted from `StatelessWidget` to `StatefulWidget with SingleTickerProviderStateMixin` to provide `vsync`.
  - Added smooth scroll button (`Icons.keyboard_double_arrow_down`) in the toolbar — only visible in vertical mode.
  - Added `_buildSmoothScrollContent`: speed Slider (0.5–10.0 px/frame, step 0.5) with close button.
  - `_buildPageTurnContent` dispatches to `_buildTimerContent` or `_buildSmoothScrollContent` based on `isSmoothScroll`.

  ## Type of change

  - :x: Bug fix
  - :white_check_mark: New feature / Enhancement — smooth scroll auto-flip for vertical reader
  - :x: Breaking change
  - :x: Refactor
  - :x: Performance
  - :x: Style
  - :x: Docs
  - :x: Chore