### PR TITLE
feat: add batch download via long-press multi-select to favorites page

### DIFF
--- a/lib/mixin/batch_select.dart
+++ b/lib/mixin/batch_select.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+import 'package:haka_comic/network/http.dart';
+import 'package:haka_comic/network/models.dart';
+import 'package:haka_comic/utils/log.dart';
+import 'package:haka_comic/views/download/background_downloader.dart';
+import 'package:haka_comic/widgets/toast.dart';
+
+mixin BatchSelectMixin<T extends StatefulWidget> on State<T> {
+  bool isSelecting = false;
+  Set<String> selectedCids = {};
+  bool isDownloading = false;
+
+  void enterSelectionMode(String uid) {
+    setState(() {
+      isSelecting = true;
+      selectedCids = {uid};
+    });
+  }
+
+  void exitSelectionMode() {
+    setState(() {
+      isSelecting = false;
+      selectedCids = {};
+    });
+  }
+
+  void toggleItem(String uid) {
+    setState(() {
+      if (selectedCids.contains(uid)) {
+        selectedCids.remove(uid);
+      } else {
+        selectedCids.add(uid);
+      }
+    });
+  }
+
+  void selectAll(List<ComicBase> comics) {
+    setState(() => selectedCids = comics.map((c) => c.uid).toSet());
+  }
+
+  void invertSelection(List<ComicBase> comics) {
+    setState(() {
+      final all = comics.map((c) => c.uid).toSet();
+      selectedCids = all.difference(selectedCids);
+    });
+  }
+
+  Future<void> batchDownload(List<ComicBase> allComics) async {
+    if (selectedCids.isEmpty) return;
+
+    setState(() => isDownloading = true);
+
+    final selected = allComics.where((c) => selectedCids.contains(c.uid)).toList();
+    int successCount = 0;
+    int failCount = 0;
+
+    try {
+      final results = await Future.wait(selected.map((comic) async {
+        try {
+          final chapters = await fetchChapters(comic.uid);
+          if (chapters.isEmpty) return false;
+
+          BackgroundDownloader.addTask(
+            ComicDownloadTask(
+              comic: DownloadComic(
+                id: comic.uid,
+                title: comic.title,
+                cover: comic.thumb.url,
+              ),
+              chapters: chapters
+                  .map((c) => DownloadChapter(id: c.uid, title: c.title, order: c.order))
+                  .toList(),
+            ),
+          );
+          return true;
+        } catch (e) {
+          Log.e('Batch download failed: ${comic.title}', error: e);
+          return false;
+        }
+      }));
+
+      successCount = results.where((r) => r).length;
+      failCount = results.where((r) => !r).length;
+    } catch (e) {
+      Log.e('Batch download error', error: e);
+    }
+
+    if (mounted) {
+      Toast.show(
+        message: failCount == 0
+            ? '已添加 $successCount 个下载任务'
+            : '成功 $successCount 个，失败 $failCount 个',
+      );
+      setState(() {
+        isSelecting = false;
+        selectedCids = {};
+        isDownloading = false;
+      });
+    }
+  }
+}

--- a/lib/views/comics/common_tmi_list.dart
+++ b/lib/views/comics/common_tmi_list.dart
@@ -65,6 +65,7 @@ class CommonTMIList extends StatelessWidget {
                 enableDefaultGestures: onItemLongPress == null ? enableDefaultGestures : false,
                 contextMenu: contextMenu,
                 isSelected: isSelected,
+                isSelecting: isSelecting,
               )
             : ListItem(
                 doc: item,
@@ -73,6 +74,7 @@ class CommonTMIList extends StatelessWidget {
                 enableDefaultGestures: onItemLongPress == null ? enableDefaultGestures : false,
                 contextMenu: contextMenu,
                 isSelected: isSelected,
+                isSelecting: isSelecting,
               );
 
         if (onItemLongPress != null) {

--- a/lib/views/comics/common_tmi_list.dart
+++ b/lib/views/comics/common_tmi_list.dart
@@ -52,6 +52,7 @@ class CommonTMIList extends StatelessWidget {
         final item = comics[index];
         final key = ValueKey(item.uid);
         final isSelected = selectedCids?.contains(item.uid) ?? false;
+        final isSelecting = selectedCids != null;
         return isSimpleMode
             ? SimpleListItem(
                 doc: item,
@@ -60,6 +61,7 @@ class CommonTMIList extends StatelessWidget {
                 enableDefaultGestures: enableDefaultGestures,
                 contextMenu: contextMenu,
                 isSelected: isSelected,
+                isSelecting: isSelecting,
                 onLongPress: onItemLongPress != null ? () => onItemLongPress!(item) : null,
               )
             : ListItem(
@@ -69,6 +71,7 @@ class CommonTMIList extends StatelessWidget {
                 enableDefaultGestures: enableDefaultGestures,
                 contextMenu: contextMenu,
                 isSelected: isSelected,
+                isSelecting: isSelecting,
                 onLongPress: onItemLongPress != null ? () => onItemLongPress!(item) : null,
               );
       },

--- a/lib/views/comics/common_tmi_list.dart
+++ b/lib/views/comics/common_tmi_list.dart
@@ -18,6 +18,7 @@ class CommonTMIList extends StatelessWidget {
     this.onItemSelected,
     this.enableDefaultGestures = true,
     this.selectedCids,
+    this.onItemLongPress,
   });
 
   final List<ComicBase> comics;
@@ -35,6 +36,8 @@ class CommonTMIList extends StatelessWidget {
   final bool enableDefaultGestures;
 
   final Set<String>? selectedCids;
+
+  final void Function(ComicBase)? onItemLongPress;
 
   bool get isSimpleMode => AppConf().comicBlockMode == ComicBlockMode.simple;
 
@@ -57,6 +60,7 @@ class CommonTMIList extends StatelessWidget {
                 enableDefaultGestures: enableDefaultGestures,
                 contextMenu: contextMenu,
                 isSelected: isSelected,
+                onLongPress: onItemLongPress != null ? () => onItemLongPress!(item) : null,
               )
             : ListItem(
                 doc: item,
@@ -65,6 +69,7 @@ class CommonTMIList extends StatelessWidget {
                 enableDefaultGestures: enableDefaultGestures,
                 contextMenu: contextMenu,
                 isSelected: isSelected,
+                onLongPress: onItemLongPress != null ? () => onItemLongPress!(item) : null,
               );
       },
     );

--- a/lib/views/comics/common_tmi_list.dart
+++ b/lib/views/comics/common_tmi_list.dart
@@ -53,27 +53,46 @@ class CommonTMIList extends StatelessWidget {
         final key = ValueKey(item.uid);
         final isSelected = selectedCids?.contains(item.uid) ?? false;
         final isSelecting = selectedCids != null;
-        return isSimpleMode
+        final void Function(dynamic, ComicBase)? itemSelected = isSelecting
+            ? (_, _) => onItemSelected?.call(null, item)
+            : onItemSelected;
+
+        Widget child = isSimpleMode
             ? SimpleListItem(
                 doc: item,
                 key: key,
-                onItemSelected: onItemSelected,
-                enableDefaultGestures: enableDefaultGestures,
+                onItemSelected: itemSelected,
+                enableDefaultGestures: onItemLongPress == null ? enableDefaultGestures : false,
                 contextMenu: contextMenu,
                 isSelected: isSelected,
-                isSelecting: isSelecting,
-                onLongPress: onItemLongPress != null ? () => onItemLongPress!(item) : null,
               )
             : ListItem(
                 doc: item,
                 key: key,
-                onItemSelected: onItemSelected,
-                enableDefaultGestures: enableDefaultGestures,
+                onItemSelected: itemSelected,
+                enableDefaultGestures: onItemLongPress == null ? enableDefaultGestures : false,
                 contextMenu: contextMenu,
                 isSelected: isSelected,
-                isSelecting: isSelecting,
-                onLongPress: onItemLongPress != null ? () => onItemLongPress!(item) : null,
               );
+
+        if (onItemLongPress != null) {
+          child = GestureDetector(
+            behavior: HitTestBehavior.translucent,
+            onLongPress: () => onItemLongPress!(item),
+            onSecondaryTapUp: contextMenu != null
+                ? (details) => showContextMenu(
+                      context,
+                      contextMenu: contextMenu!.copyWith(
+                        position: contextMenu!.position ?? details.globalPosition,
+                      ),
+                      onItemSelected: (value) => onItemSelected?.call(value, item),
+                    )
+                : null,
+            child: child,
+          );
+        }
+
+        return child;
       },
     );
   }

--- a/lib/views/comics/common_tmi_list.dart
+++ b/lib/views/comics/common_tmi_list.dart
@@ -17,6 +17,7 @@ class CommonTMIList extends StatelessWidget {
     this.contextMenu,
     this.onItemSelected,
     this.enableDefaultGestures = true,
+    this.selectedCids,
   });
 
   final List<ComicBase> comics;
@@ -33,6 +34,8 @@ class CommonTMIList extends StatelessWidget {
 
   final bool enableDefaultGestures;
 
+  final Set<String>? selectedCids;
+
   bool get isSimpleMode => AppConf().comicBlockMode == ComicBlockMode.simple;
 
   @override
@@ -45,6 +48,7 @@ class CommonTMIList extends StatelessWidget {
       itemBuilder: (context, index) {
         final item = comics[index];
         final key = ValueKey(item.uid);
+        final isSelected = selectedCids?.contains(item.uid) ?? false;
         return isSimpleMode
             ? SimpleListItem(
                 doc: item,
@@ -52,6 +56,7 @@ class CommonTMIList extends StatelessWidget {
                 onItemSelected: onItemSelected,
                 enableDefaultGestures: enableDefaultGestures,
                 contextMenu: contextMenu,
+                isSelected: isSelected,
               )
             : ListItem(
                 doc: item,
@@ -59,6 +64,7 @@ class CommonTMIList extends StatelessWidget {
                 onItemSelected: onItemSelected,
                 enableDefaultGestures: enableDefaultGestures,
                 contextMenu: contextMenu,
+                isSelected: isSelected,
               );
       },
     );

--- a/lib/views/comics/list_item.dart
+++ b/lib/views/comics/list_item.dart
@@ -15,6 +15,7 @@ class ListItem extends StatelessWidget {
     this.onItemSelected,
     this.enableDefaultGestures = true,
     this.isSelected = false,
+    this.isSelecting = false,
   });
 
   final ComicBase doc;
@@ -22,6 +23,7 @@ class ListItem extends StatelessWidget {
   final void Function(dynamic, ComicBase)? onItemSelected;
   final bool enableDefaultGestures;
   final bool isSelected;
+  final bool isSelecting;
 
   @override
   Widget build(BuildContext context) {
@@ -80,7 +82,9 @@ class ListItem extends StatelessWidget {
   Widget _buildContent(BuildContext context, ComicBase item) {
     return InkWell(
       borderRadius: .circular(12),
-      onTap: () => context.push('/details/${item.uid}'),
+      onTap: isSelecting
+          ? () => onItemSelected?.call(null, item)
+          : () => context.push('/details/${item.uid}'),
       child: Container(
         padding: const .symmetric(vertical: 5, horizontal: 10),
         decoration: isSelected

--- a/lib/views/comics/list_item.dart
+++ b/lib/views/comics/list_item.dart
@@ -15,8 +15,6 @@ class ListItem extends StatelessWidget {
     this.onItemSelected,
     this.enableDefaultGestures = true,
     this.isSelected = false,
-    this.isSelecting = false,
-    this.onLongPress,
   });
 
   final ComicBase doc;
@@ -24,40 +22,18 @@ class ListItem extends StatelessWidget {
   final void Function(dynamic, ComicBase)? onItemSelected;
   final bool enableDefaultGestures;
   final bool isSelected;
-  final bool isSelecting;
-  final VoidCallback? onLongPress;
 
   @override
   Widget build(BuildContext context) {
     final item = doc;
-    final bool useCustomGesture = onLongPress != null;
 
     Widget child = _buildContent(context, item);
 
     if (contextMenu != null) {
       child = ContextMenuRegion(
         contextMenu: contextMenu!,
-        enableDefaultGestures: useCustomGesture ? false : enableDefaultGestures,
+        enableDefaultGestures: enableDefaultGestures,
         onItemSelected: (value) => onItemSelected?.call(value, item),
-        child: child,
-      );
-    }
-
-    if (useCustomGesture) {
-      child = GestureDetector(
-        behavior: HitTestBehavior.translucent,
-        onLongPress: onLongPress,
-        onSecondaryTapUp: contextMenu != null
-            ? (details) {
-                showContextMenu(
-                  context,
-                  contextMenu: contextMenu!.copyWith(
-                    position: contextMenu!.position ?? details.globalPosition,
-                  ),
-                  onItemSelected: (value) => onItemSelected?.call(value, item),
-                );
-              }
-            : null,
         child: child,
       );
     }
@@ -104,9 +80,7 @@ class ListItem extends StatelessWidget {
   Widget _buildContent(BuildContext context, ComicBase item) {
     return InkWell(
       borderRadius: .circular(12),
-      onTap: isSelecting
-          ? () => onItemSelected?.call(null, item)
-          : () => context.push('/details/${item.uid}'),
+      onTap: () => context.push('/details/${item.uid}'),
       child: Container(
         padding: const .symmetric(vertical: 5, horizontal: 10),
         decoration: isSelected

--- a/lib/views/comics/list_item.dart
+++ b/lib/views/comics/list_item.dart
@@ -98,7 +98,6 @@ class ListItem extends StatelessWidget {
       onTap: isSelecting
           ? () => onItemSelected?.call(null, item)
           : () => context.push('/details/${item.uid}'),
-      onLongPress: onLongPress,
       child: Container(
         padding: const .symmetric(vertical: 5, horizontal: 10),
         decoration: isSelected

--- a/lib/views/comics/list_item.dart
+++ b/lib/views/comics/list_item.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:haka_comic/network/models.dart';
 import 'package:haka_comic/utils/common.dart';
 import 'package:haka_comic/utils/extension.dart';
+import 'package:haka_comic/utils/log.dart';
 import 'package:haka_comic/widgets/tag.dart';
 import 'package:haka_comic/widgets/ui_image.dart';
 
@@ -20,42 +21,62 @@ class ListItem extends StatelessWidget {
   });
 
   final ComicBase doc;
-
   final ContextMenu? contextMenu;
-
   final void Function(dynamic, ComicBase)? onItemSelected;
-
   final bool enableDefaultGestures;
-
   final bool isSelected;
-
   final bool isSelecting;
-
   final VoidCallback? onLongPress;
 
   @override
   Widget build(BuildContext context) {
     final item = doc;
+    final bool useCustomGesture = onLongPress != null;
+
+    // 关键诊断日志：确认参数是否正确传入
+    Log.i('ListItem', 'build: onLongPress=${onLongPress != null}, contextMenu=${contextMenu != null}, useCustomGesture=$useCustomGesture');
+
+    Widget child = _buildContent(context, item);
+
+    if (contextMenu != null) {
+      child = ContextMenuRegion(
+        contextMenu: contextMenu!,
+        enableDefaultGestures: useCustomGesture ? false : enableDefaultGestures,
+        onItemSelected: (value) => onItemSelected?.call(value, item),
+        child: child,
+      );
+    }
+
+    if (useCustomGesture) {
+      child = Listener(
+        // 最底层指针事件——如果这个都没触发，说明事件被上层拦截了
+        onPointerDown: (e) => Log.i('ListItem', 'Listener.onPointerDown'),
+        onPointerUp: (e) => Log.i('ListItem', 'Listener.onPointerUp'),
+        child: GestureDetector(
+          behavior: HitTestBehavior.translucent,
+          onLongPress: () {
+            Log.i('ListItem', '>>> onLongPress FIRED <<<');
+            onLongPress!();
+          },
+          onSecondaryTapUp: contextMenu != null
+              ? (details) {
+                  showContextMenu(
+                    context,
+                    contextMenu: contextMenu!.copyWith(
+                      position: contextMenu!.position ?? details.globalPosition,
+                    ),
+                    onItemSelected: (value) => onItemSelected?.call(value, item),
+                  );
+                }
+              : null,
+          child: child,
+        ),
+      );
+    }
 
     return Stack(
       children: [
-        Positioned.fill(
-          child: contextMenu != null
-              ? ContextMenuRegion(
-                  contextMenu: contextMenu!,
-                  enableDefaultGestures: enableDefaultGestures,
-                  onItemSelected: (value) => onItemSelected?.call(value, item),
-                  builder: onLongPress != null
-                      ? (ctx, menu, _, showMenu, child) => GestureDetector(
-                            onLongPressStart: (d) => onLongPress!(),
-                            onSecondaryTapUp: (d) => showMenu(d.globalPosition),
-                            child: child,
-                          )
-                      : null,
-                  child: _buildContent(context, item),
-                )
-              : _buildContent(context, item),
-        ),
+        Positioned.fill(child: child),
 
         if (item.finished)
           Positioned(

--- a/lib/views/comics/list_item.dart
+++ b/lib/views/comics/list_item.dart
@@ -45,21 +45,21 @@ class ListItem extends StatelessWidget {
 
     if (useCustomGesture) {
       child = GestureDetector(
-          behavior: HitTestBehavior.translucent,
-          onLongPress: onLongPress,
-          onSecondaryTapUp: contextMenu != null
-              ? (details) {
-                  showContextMenu(
-                    context,
-                    contextMenu: contextMenu!.copyWith(
-                      position: contextMenu!.position ?? details.globalPosition,
-                    ),
-                    onItemSelected: (value) => onItemSelected?.call(value, item),
-                  );
-                }
-              : null,
-          child: child,
-        );
+        behavior: HitTestBehavior.translucent,
+        onLongPress: onLongPress,
+        onSecondaryTapUp: contextMenu != null
+            ? (details) {
+                showContextMenu(
+                  context,
+                  contextMenu: contextMenu!.copyWith(
+                    position: contextMenu!.position ?? details.globalPosition,
+                  ),
+                  onItemSelected: (value) => onItemSelected?.call(value, item),
+                );
+              }
+            : null,
+        child: child,
+      );
     }
 
     return Stack(

--- a/lib/views/comics/list_item.dart
+++ b/lib/views/comics/list_item.dart
@@ -15,6 +15,7 @@ class ListItem extends StatelessWidget {
     this.onItemSelected,
     this.enableDefaultGestures = true,
     this.isSelected = false,
+    this.onLongPress,
   });
 
   final ComicBase doc;
@@ -26,6 +27,8 @@ class ListItem extends StatelessWidget {
   final bool enableDefaultGestures;
 
   final bool isSelected;
+
+  final VoidCallback? onLongPress;
 
   @override
   Widget build(BuildContext context) {
@@ -85,6 +88,7 @@ class ListItem extends StatelessWidget {
       onTap: () {
         context.push('/details/${item.uid}');
       },
+      onLongPress: onLongPress,
       child: Container(
         padding: const .symmetric(vertical: 5, horizontal: 10),
         decoration: isSelected

--- a/lib/views/comics/list_item.dart
+++ b/lib/views/comics/list_item.dart
@@ -45,6 +45,13 @@ class ListItem extends StatelessWidget {
                   contextMenu: contextMenu!,
                   enableDefaultGestures: enableDefaultGestures,
                   onItemSelected: (value) => onItemSelected?.call(value, item),
+                  builder: onLongPress != null
+                      ? (ctx, menu, _, showMenu, child) => GestureDetector(
+                            onLongPressStart: (d) => onLongPress!(),
+                            onSecondaryTapUp: (d) => showMenu(d.globalPosition),
+                            child: child,
+                          )
+                      : null,
                   child: _buildContent(context, item),
                 )
               : _buildContent(context, item),

--- a/lib/views/comics/list_item.dart
+++ b/lib/views/comics/list_item.dart
@@ -4,7 +4,6 @@ import 'package:go_router/go_router.dart';
 import 'package:haka_comic/network/models.dart';
 import 'package:haka_comic/utils/common.dart';
 import 'package:haka_comic/utils/extension.dart';
-import 'package:haka_comic/utils/log.dart';
 import 'package:haka_comic/widgets/tag.dart';
 import 'package:haka_comic/widgets/ui_image.dart';
 
@@ -33,9 +32,6 @@ class ListItem extends StatelessWidget {
     final item = doc;
     final bool useCustomGesture = onLongPress != null;
 
-    // 关键诊断日志：确认参数是否正确传入
-    Log.i('ListItem', 'build: onLongPress=${onLongPress != null}, contextMenu=${contextMenu != null}, useCustomGesture=$useCustomGesture');
-
     Widget child = _buildContent(context, item);
 
     if (contextMenu != null) {
@@ -48,16 +44,9 @@ class ListItem extends StatelessWidget {
     }
 
     if (useCustomGesture) {
-      child = Listener(
-        // 最底层指针事件——如果这个都没触发，说明事件被上层拦截了
-        onPointerDown: (e) => Log.i('ListItem', 'Listener.onPointerDown'),
-        onPointerUp: (e) => Log.i('ListItem', 'Listener.onPointerUp'),
-        child: GestureDetector(
+      child = GestureDetector(
           behavior: HitTestBehavior.translucent,
-          onLongPress: () {
-            Log.i('ListItem', '>>> onLongPress FIRED <<<');
-            onLongPress!();
-          },
+          onLongPress: onLongPress,
           onSecondaryTapUp: contextMenu != null
               ? (details) {
                   showContextMenu(
@@ -70,8 +59,7 @@ class ListItem extends StatelessWidget {
                 }
               : null,
           child: child,
-        ),
-      );
+        );
     }
 
     return Stack(

--- a/lib/views/comics/list_item.dart
+++ b/lib/views/comics/list_item.dart
@@ -15,6 +15,7 @@ class ListItem extends StatelessWidget {
     this.onItemSelected,
     this.enableDefaultGestures = true,
     this.isSelected = false,
+    this.isSelecting = false,
     this.onLongPress,
   });
 
@@ -27,6 +28,8 @@ class ListItem extends StatelessWidget {
   final bool enableDefaultGestures;
 
   final bool isSelected;
+
+  final bool isSelecting;
 
   final VoidCallback? onLongPress;
 
@@ -85,9 +88,9 @@ class ListItem extends StatelessWidget {
   Widget _buildContent(BuildContext context, ComicBase item) {
     return InkWell(
       borderRadius: .circular(12),
-      onTap: () {
-        context.push('/details/${item.uid}');
-      },
+      onTap: isSelecting
+          ? () => onItemSelected?.call(null, item)
+          : () => context.push('/details/${item.uid}'),
       onLongPress: onLongPress,
       child: Container(
         padding: const .symmetric(vertical: 5, horizontal: 10),

--- a/lib/views/comics/list_item.dart
+++ b/lib/views/comics/list_item.dart
@@ -14,6 +14,7 @@ class ListItem extends StatelessWidget {
     this.contextMenu,
     this.onItemSelected,
     this.enableDefaultGestures = true,
+    this.isSelected = false,
   });
 
   final ComicBase doc;
@@ -23,6 +24,8 @@ class ListItem extends StatelessWidget {
   final void Function(dynamic, ComicBase)? onItemSelected;
 
   final bool enableDefaultGestures;
+
+  final bool isSelected;
 
   @override
   Widget build(BuildContext context) {
@@ -84,6 +87,12 @@ class ListItem extends StatelessWidget {
       },
       child: Container(
         padding: const .symmetric(vertical: 5, horizontal: 10),
+        decoration: isSelected
+            ? BoxDecoration(
+                color: context.colorScheme.secondaryContainer.withValues(alpha: 0.65),
+                borderRadius: BorderRadius.circular(12),
+              )
+            : null,
         child: Row(
           spacing: 8,
           crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/views/comics/simple_list_item.dart
+++ b/lib/views/comics/simple_list_item.dart
@@ -3,6 +3,7 @@ import 'package:flutter_context_menu/flutter_context_menu.dart';
 import 'package:go_router/go_router.dart';
 import 'package:haka_comic/network/models.dart';
 import 'package:haka_comic/utils/extension.dart';
+import 'package:haka_comic/utils/log.dart';
 import 'package:haka_comic/widgets/ui_image.dart';
 
 class SimpleListItem extends StatelessWidget {
@@ -18,42 +19,55 @@ class SimpleListItem extends StatelessWidget {
   });
 
   final ComicBase doc;
-
   final ContextMenu? contextMenu;
-
   final void Function(dynamic, ComicBase)? onItemSelected;
-
   final bool enableDefaultGestures;
-
   final bool isSelected;
-
   final bool isSelecting;
-
   final VoidCallback? onLongPress;
 
   @override
   Widget build(BuildContext context) {
     final item = doc;
 
+    final bool useCustomGesture = onLongPress != null;
+
+    Widget child = _buildContent(context, item);
+
+    if (contextMenu != null) {
+      child = ContextMenuRegion(
+        contextMenu: contextMenu!,
+        enableDefaultGestures: useCustomGesture ? false : enableDefaultGestures,
+        onItemSelected: (value) => onItemSelected?.call(value, item),
+        child: child,
+      );
+    }
+
+    if (useCustomGesture) {
+      child = GestureDetector(
+        behavior: HitTestBehavior.translucent,
+        onLongPress: () {
+          Log.i('SimpleListItem', 'onLongPress fired');
+          onLongPress!();
+        },
+        onSecondaryTapUp: contextMenu != null
+            ? (details) {
+                showContextMenu(
+                  context,
+                  contextMenu: contextMenu!.copyWith(
+                    position: contextMenu!.position ?? details.globalPosition,
+                  ),
+                  onItemSelected: (value) => onItemSelected?.call(value, item),
+                );
+              }
+            : null,
+        child: child,
+      );
+    }
+
     return Stack(
       children: [
-        Positioned.fill(
-          child: contextMenu != null
-              ? ContextMenuRegion(
-                  contextMenu: contextMenu!,
-                  enableDefaultGestures: enableDefaultGestures,
-                  onItemSelected: (value) => onItemSelected?.call(value, item),
-                  builder: onLongPress != null
-                      ? (ctx, menu, _, showMenu, child) => GestureDetector(
-                            onLongPressStart: (d) => onLongPress!(),
-                            onSecondaryTapUp: (d) => showMenu(d.globalPosition),
-                            child: child,
-                          )
-                      : null,
-                  child: _buildContent(context, item),
-                )
-              : _buildContent(context, item),
-        ),
+        Positioned.fill(child: child),
 
         if (item.finished)
           Positioned(
@@ -109,7 +123,7 @@ class SimpleListItem extends StatelessWidget {
               ),
               Text(
                 item.title,
-                style: context.textTheme.titleSmall,
+                style: context.textTheme.labelSmall,
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
                 textAlign: TextAlign.center,

--- a/lib/views/comics/simple_list_item.dart
+++ b/lib/views/comics/simple_list_item.dart
@@ -86,7 +86,6 @@ class SimpleListItem extends StatelessWidget {
       onTap: isSelecting
           ? () => onItemSelected?.call(null, item)
           : () => context.push('/details/${item.uid}'),
-      onLongPress: onLongPress,
       child: Container(
         padding: const EdgeInsets.all(2),
         decoration: isSelected

--- a/lib/views/comics/simple_list_item.dart
+++ b/lib/views/comics/simple_list_item.dart
@@ -13,6 +13,7 @@ class SimpleListItem extends StatelessWidget {
     this.onItemSelected,
     this.enableDefaultGestures = true,
     this.isSelected = false,
+    this.onLongPress,
   });
 
   final ComicBase doc;
@@ -24,6 +25,8 @@ class SimpleListItem extends StatelessWidget {
   final bool enableDefaultGestures;
 
   final bool isSelected;
+
+  final VoidCallback? onLongPress;
 
   @override
   Widget build(BuildContext context) {
@@ -73,6 +76,7 @@ class SimpleListItem extends StatelessWidget {
       onTap: () {
         context.push('/details/${item.uid}');
       },
+      onLongPress: onLongPress,
       child: Container(
         padding: const EdgeInsets.all(2),
         decoration: isSelected

--- a/lib/views/comics/simple_list_item.dart
+++ b/lib/views/comics/simple_list_item.dart
@@ -3,7 +3,6 @@ import 'package:flutter_context_menu/flutter_context_menu.dart';
 import 'package:go_router/go_router.dart';
 import 'package:haka_comic/network/models.dart';
 import 'package:haka_comic/utils/extension.dart';
-import 'package:haka_comic/utils/log.dart';
 import 'package:haka_comic/widgets/ui_image.dart';
 
 class SimpleListItem extends StatelessWidget {
@@ -46,10 +45,7 @@ class SimpleListItem extends StatelessWidget {
     if (useCustomGesture) {
       child = GestureDetector(
         behavior: HitTestBehavior.translucent,
-        onLongPress: () {
-          Log.i('SimpleListItem', 'onLongPress fired');
-          onLongPress!();
-        },
+        onLongPress: onLongPress,
         onSecondaryTapUp: contextMenu != null
             ? (details) {
                 showContextMenu(

--- a/lib/views/comics/simple_list_item.dart
+++ b/lib/views/comics/simple_list_item.dart
@@ -13,6 +13,7 @@ class SimpleListItem extends StatelessWidget {
     this.onItemSelected,
     this.enableDefaultGestures = true,
     this.isSelected = false,
+    this.isSelecting = false,
     this.onLongPress,
   });
 
@@ -25,6 +26,8 @@ class SimpleListItem extends StatelessWidget {
   final bool enableDefaultGestures;
 
   final bool isSelected;
+
+  final bool isSelecting;
 
   final VoidCallback? onLongPress;
 
@@ -73,9 +76,9 @@ class SimpleListItem extends StatelessWidget {
   Widget _buildContent(BuildContext context, ComicBase item) {
     return InkWell(
       borderRadius: .circular(12),
-      onTap: () {
-        context.push('/details/${item.uid}');
-      },
+      onTap: isSelecting
+          ? () => onItemSelected?.call(null, item)
+          : () => context.push('/details/${item.uid}'),
       onLongPress: onLongPress,
       child: Container(
         padding: const EdgeInsets.all(2),

--- a/lib/views/comics/simple_list_item.dart
+++ b/lib/views/comics/simple_list_item.dart
@@ -12,6 +12,7 @@ class SimpleListItem extends StatelessWidget {
     this.contextMenu,
     this.onItemSelected,
     this.enableDefaultGestures = true,
+    this.isSelected = false,
   });
 
   final ComicBase doc;
@@ -21,6 +22,8 @@ class SimpleListItem extends StatelessWidget {
   final void Function(dynamic, ComicBase)? onItemSelected;
 
   final bool enableDefaultGestures;
+
+  final bool isSelected;
 
   @override
   Widget build(BuildContext context) {
@@ -72,6 +75,12 @@ class SimpleListItem extends StatelessWidget {
       },
       child: Container(
         padding: const EdgeInsets.all(2),
+        decoration: isSelected
+            ? BoxDecoration(
+                color: context.colorScheme.secondaryContainer.withValues(alpha: 0.65),
+                borderRadius: BorderRadius.circular(12),
+              )
+            : null,
         child: SingleChildScrollView(
           child: Column(
             spacing: 3,

--- a/lib/views/comics/simple_list_item.dart
+++ b/lib/views/comics/simple_list_item.dart
@@ -13,8 +13,6 @@ class SimpleListItem extends StatelessWidget {
     this.onItemSelected,
     this.enableDefaultGestures = true,
     this.isSelected = false,
-    this.isSelecting = false,
-    this.onLongPress,
   });
 
   final ComicBase doc;
@@ -22,41 +20,18 @@ class SimpleListItem extends StatelessWidget {
   final void Function(dynamic, ComicBase)? onItemSelected;
   final bool enableDefaultGestures;
   final bool isSelected;
-  final bool isSelecting;
-  final VoidCallback? onLongPress;
 
   @override
   Widget build(BuildContext context) {
     final item = doc;
-
-    final bool useCustomGesture = onLongPress != null;
 
     Widget child = _buildContent(context, item);
 
     if (contextMenu != null) {
       child = ContextMenuRegion(
         contextMenu: contextMenu!,
-        enableDefaultGestures: useCustomGesture ? false : enableDefaultGestures,
+        enableDefaultGestures: enableDefaultGestures,
         onItemSelected: (value) => onItemSelected?.call(value, item),
-        child: child,
-      );
-    }
-
-    if (useCustomGesture) {
-      child = GestureDetector(
-        behavior: HitTestBehavior.translucent,
-        onLongPress: onLongPress,
-        onSecondaryTapUp: contextMenu != null
-            ? (details) {
-                showContextMenu(
-                  context,
-                  contextMenu: contextMenu!.copyWith(
-                    position: contextMenu!.position ?? details.globalPosition,
-                  ),
-                  onItemSelected: (value) => onItemSelected?.call(value, item),
-                );
-              }
-            : null,
         child: child,
       );
     }
@@ -93,9 +68,7 @@ class SimpleListItem extends StatelessWidget {
   Widget _buildContent(BuildContext context, ComicBase item) {
     return InkWell(
       borderRadius: .circular(12),
-      onTap: isSelecting
-          ? () => onItemSelected?.call(null, item)
-          : () => context.push('/details/${item.uid}'),
+      onTap: () => context.push('/details/${item.uid}'),
       child: Container(
         padding: const EdgeInsets.all(2),
         decoration: isSelected

--- a/lib/views/comics/simple_list_item.dart
+++ b/lib/views/comics/simple_list_item.dart
@@ -43,6 +43,13 @@ class SimpleListItem extends StatelessWidget {
                   contextMenu: contextMenu!,
                   enableDefaultGestures: enableDefaultGestures,
                   onItemSelected: (value) => onItemSelected?.call(value, item),
+                  builder: onLongPress != null
+                      ? (ctx, menu, _, showMenu, child) => GestureDetector(
+                            onLongPressStart: (d) => onLongPress!(),
+                            onSecondaryTapUp: (d) => showMenu(d.globalPosition),
+                            child: child,
+                          )
+                      : null,
                   child: _buildContent(context, item),
                 )
               : _buildContent(context, item),

--- a/lib/views/comics/simple_list_item.dart
+++ b/lib/views/comics/simple_list_item.dart
@@ -119,7 +119,7 @@ class SimpleListItem extends StatelessWidget {
               ),
               Text(
                 item.title,
-                style: context.textTheme.labelSmall,
+                style: context.textTheme.titleSmall,
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
                 textAlign: TextAlign.center,

--- a/lib/views/comics/simple_list_item.dart
+++ b/lib/views/comics/simple_list_item.dart
@@ -13,6 +13,7 @@ class SimpleListItem extends StatelessWidget {
     this.onItemSelected,
     this.enableDefaultGestures = true,
     this.isSelected = false,
+    this.isSelecting = false,
   });
 
   final ComicBase doc;
@@ -20,6 +21,7 @@ class SimpleListItem extends StatelessWidget {
   final void Function(dynamic, ComicBase)? onItemSelected;
   final bool enableDefaultGestures;
   final bool isSelected;
+  final bool isSelecting;
 
   @override
   Widget build(BuildContext context) {
@@ -68,7 +70,9 @@ class SimpleListItem extends StatelessWidget {
   Widget _buildContent(BuildContext context, ComicBase item) {
     return InkWell(
       borderRadius: .circular(12),
-      onTap: () => context.push('/details/${item.uid}'),
+      onTap: isSelecting
+          ? () => onItemSelected?.call(null, item)
+          : () => context.push('/details/${item.uid}'),
       child: Container(
         padding: const EdgeInsets.all(2),
         decoration: isSelected

--- a/lib/views/local_favorites/folder_comics.dart
+++ b/lib/views/local_favorites/folder_comics.dart
@@ -2,12 +2,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_context_menu/flutter_context_menu.dart';
 import 'package:haka_comic/database/local_favorites_helper.dart';
+import 'package:haka_comic/network/http.dart';
 import 'package:haka_comic/network/models.dart';
 import 'package:haka_comic/utils/common.dart';
 import 'package:haka_comic/utils/extension.dart';
 import 'package:haka_comic/utils/log.dart';
 import 'package:haka_comic/utils/request/request.dart';
 import 'package:haka_comic/views/comics/common_tmi_list.dart';
+import 'package:haka_comic/views/download/background_downloader.dart';
 import 'package:haka_comic/widgets/empty.dart';
 import 'package:haka_comic/widgets/error_page.dart';
 import 'package:haka_comic/widgets/toast.dart';
@@ -28,6 +30,10 @@ class _FolderComicsState extends State<FolderComics> with RequestMixin {
 
   bool _isSearching = false;
   String _keyword = '';
+  
+  bool _isSelecting = false;
+  Set<String> _selectedCids = {};
+  bool _isDownloading = false;
 
   late final _getFolderComicsHandler = _helper.getFolderComics.useRequest(
     manual: true,
@@ -86,6 +92,17 @@ class _FolderComicsState extends State<FolderComics> with RequestMixin {
   late final menu = ContextMenu(entries: entries, padding: const .all(8.0));
 
   void _onItemSelected(dynamic key, ComicBase item) async {
+    if (_isSelecting) {
+      setState(() {
+        if (_selectedCids.contains(item.uid)) {
+          _selectedCids.remove(item.uid);
+        } else {
+          _selectedCids.add(item.uid);
+        }
+      });
+      return;
+    }
+    
     switch (key) {
       case 'copy':
         final title = item.title;
@@ -123,6 +140,101 @@ class _FolderComicsState extends State<FolderComics> with RequestMixin {
     _searchController.dispose();
     _searchFocusNode.dispose();
     super.dispose();
+  }
+
+  void _enterSelectionMode() {
+    setState(() => _isSelecting = true);
+  }
+
+  void _exitSelectionMode() {
+    setState(() {
+      _isSelecting = false;
+      _selectedCids.clear();
+    });
+  }
+
+  void _selectAll(List<ComicBase> comics) {
+    setState(() {
+      _selectedCids = comics.map((c) => c.uid).toSet();
+    });
+  }
+
+  void _deselectAll() {
+    setState(() => _selectedCids.clear());
+  }
+
+  void _invertSelection(List<ComicBase> comics) {
+    setState(() {
+      final allCids = comics.map((c) => c.uid).toSet();
+      _selectedCids = allCids.difference(_selectedCids);
+    });
+  }
+
+  Future<void> _batchDownload() async {
+    if (_selectedCids.isEmpty) return;
+    
+    setState(() => _isDownloading = true);
+    
+    final comics = _getFolderComicsHandler.state.data ?? [];
+    final selectedComics = comics.where((c) => _selectedCids.contains(c.uid)).toList();
+    
+    int successCount = 0;
+    int failCount = 0;
+    
+    try {
+      for (var comic in selectedComics) {
+        try {
+          final chapters = await fetchChapters(comic.uid);
+          if (chapters.isEmpty) {
+            failCount++;
+            continue;
+          }
+          
+          final downloadChapters = chapters
+              .map((chapter) => DownloadChapter(
+                id: chapter.uid,
+                title: chapter.title,
+                order: chapter.order,
+              ))
+              .toList();
+          
+          BackgroundDownloader.addTask(
+            ComicDownloadTask(
+              comic: DownloadComic(
+                id: comic.uid,
+                title: comic.title,
+                cover: comic.thumb.url,
+              ),
+              chapters: downloadChapters,
+            ),
+          );
+          
+          successCount++;
+        } catch (e) {
+          Log.e('Batch download comic failed', error: e);
+          failCount++;
+        }
+      }
+      
+      if (mounted) {
+        if (failCount == 0) {
+          Toast.show(message: '已添加 $successCount 个下载任务');
+        } else {
+          Toast.show(message: '成功 $successCount 个，失败 $failCount 个');
+        }
+        setState(() {
+          _isSelecting = false;
+          _selectedCids.clear();
+          _isDownloading = false;
+        });
+      }
+    } catch (e) {
+      Log.e('Batch download error', error: e);
+      Toast.show(message: '批量下载失败');
+      if (mounted) {
+        setState(() => _isDownloading = false);
+      }
+    }
   }
 
   void _openSearch() {
@@ -164,7 +276,7 @@ class _FolderComicsState extends State<FolderComics> with RequestMixin {
     }).toList();
   }
 
-  Widget _header(BuildContext context) {
+  Widget _header(BuildContext context, List<ComicBase> allComics) {
     return Padding(
       padding: const .symmetric(horizontal: 8, vertical: 4),
       child: _isSearching
@@ -202,21 +314,53 @@ class _FolderComicsState extends State<FolderComics> with RequestMixin {
                 ),
               ],
             )
-          : Row(
-              spacing: 5,
-              children: [
-                Text(
-                  '收藏夹:${widget.folder?.name ?? '全部'}',
-                  style: context.textTheme.titleMedium,
+          : _isSelecting
+              ? Row(
+                  spacing: 5,
+                  children: [
+                    IconButton(
+                      icon: const Icon(Icons.close),
+                      tooltip: '关闭',
+                      onPressed: _exitSelectionMode,
+                    ),
+                    Expanded(
+                      child: Text(
+                        '已选 ${_selectedCids.length} 项',
+                        style: context.textTheme.titleMedium,
+                      ),
+                    ),
+                    IconButton(
+                      icon: const Icon(Icons.select_all),
+                      tooltip: '全选',
+                      onPressed: () => _selectAll(allComics),
+                    ),
+                    IconButton(
+                      icon: const Icon(Icons.repeat),
+                      tooltip: '反选',
+                      onPressed: () => _invertSelection(allComics),
+                    ),
+                  ],
+                )
+              : Row(
+                  spacing: 5,
+                  children: [
+                    Text(
+                      '收藏夹:${widget.folder?.name ?? '全部'}',
+                      style: context.textTheme.titleMedium,
+                    ),
+                    const Spacer(),
+                    IconButton(
+                      icon: const Icon(Icons.search),
+                      tooltip: '搜索',
+                      onPressed: _openSearch,
+                    ),
+                    IconButton(
+                      icon: const Icon(Icons.checklist_rtl),
+                      tooltip: '多选',
+                      onPressed: _enterSelectionMode,
+                    ),
+                  ],
                 ),
-                const Spacer(),
-                IconButton(
-                  icon: const Icon(Icons.search),
-                  tooltip: '搜索',
-                  onPressed: _openSearch,
-                ),
-              ],
-            ),
     );
   }
 
@@ -227,21 +371,48 @@ class _FolderComicsState extends State<FolderComics> with RequestMixin {
         if (data.isEmpty) return const Empty();
 
         final filtered = _filterComics(data);
-        return Column(
-          children: [
-            _header(context),
-            Expanded(
-              child: filtered.isEmpty
-                  ? const Empty()
-                  : CommonTMIList(
-                      onItemSelected: widget.folder == null
-                          ? null
-                          : _onItemSelected,
-                      contextMenu: widget.folder == null ? null : menu,
-                      comics: filtered,
+        
+        return Scaffold(
+          body: Column(
+            children: [
+              _header(context, filtered),
+              Expanded(
+                child: filtered.isEmpty
+                    ? const Empty()
+                    : CommonTMIList(
+                        onItemSelected: widget.folder == null
+                            ? null
+                            : (key, comic) {
+                                if (_isSelecting) {
+                                  _onItemSelected(null, comic);
+                                } else {
+                                  _onItemSelected(key, comic);
+                                }
+                              },
+                        contextMenu: _isSelecting ? null : (widget.folder == null ? null : menu),
+                        comics: filtered,
+                        selectedCids: _isSelecting ? _selectedCids : null,
+                      ),
+              ),
+            ],
+          ),
+          persistentFooterButtons: _isSelecting && _selectedCids.isNotEmpty
+              ? [
+                  SizedBox(
+                    width: double.infinity,
+                    child: FilledButton(
+                      onPressed: _isDownloading ? null : _batchDownload,
+                      child: _isDownloading
+                          ? const SizedBox(
+                              height: 20,
+                              width: 20,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            )
+                          : Text('批量下载(${_selectedCids.length})'),
                     ),
-            ),
-          ],
+                  ),
+                ]
+              : null,
         );
       }(),
       Error(:final error) => ErrorPage(

--- a/lib/views/local_favorites/folder_comics.dart
+++ b/lib/views/local_favorites/folder_comics.dart
@@ -2,14 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_context_menu/flutter_context_menu.dart';
 import 'package:haka_comic/database/local_favorites_helper.dart';
-import 'package:haka_comic/network/http.dart';
 import 'package:haka_comic/network/models.dart';
 import 'package:haka_comic/utils/common.dart';
 import 'package:haka_comic/utils/extension.dart';
 import 'package:haka_comic/utils/log.dart';
 import 'package:haka_comic/utils/request/request.dart';
 import 'package:haka_comic/views/comics/common_tmi_list.dart';
-import 'package:haka_comic/views/download/background_downloader.dart';
 import 'package:haka_comic/widgets/empty.dart';
 import 'package:haka_comic/widgets/error_page.dart';
 import 'package:haka_comic/widgets/toast.dart';
@@ -30,12 +28,6 @@ class _FolderComicsState extends State<FolderComics> with RequestMixin {
 
   bool _isSearching = false;
   String _keyword = '';
-  String _lastKeyword = '';
-  List<ComicBase> _cachedFiltered = [];
-  
-  bool _isSelecting = false;
-  Set<String> _selectedCids = {};
-  bool _isDownloading = false;
 
   late final _getFolderComicsHandler = _helper.getFolderComics.useRequest(
     manual: true,
@@ -93,22 +85,11 @@ class _FolderComicsState extends State<FolderComics> with RequestMixin {
 
   late final menu = ContextMenu(entries: entries, padding: const .all(8.0));
 
-  void _onItemSelected(dynamic key, ComicBase item) {
-    if (_isSelecting) {
-      setState(() {
-        if (_selectedCids.contains(item.uid)) {
-          _selectedCids.remove(item.uid);
-        } else {
-          _selectedCids.add(item.uid);
-        }
-      });
-      return;
-    }
-    
+  void _onItemSelected(dynamic key, ComicBase item) async {
     switch (key) {
       case 'copy':
         final title = item.title;
-        Clipboard.setData(ClipboardData(text: title));
+        await Clipboard.setData(ClipboardData(text: title));
         Toast.show(message: '已复制');
         break;
       case 'delete':
@@ -133,11 +114,6 @@ class _FolderComicsState extends State<FolderComics> with RequestMixin {
   didUpdateWidget(covariant FolderComics oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.folder?.id != oldWidget.folder?.id) {
-      _lastKeyword = '';
-      _cachedFiltered = [];
-      _selectedCids.clear();
-      _isSelecting = false;
-      _isDownloading = false;
       _getFolderComicsHandler.run(widget.folder?.id);
     }
   }
@@ -149,94 +125,7 @@ class _FolderComicsState extends State<FolderComics> with RequestMixin {
     super.dispose();
   }
 
-  void _exitSelectionMode() {
-    setState(() {
-      _isSelecting = false;
-      _selectedCids.clear();
-    });
-  }
-
-  void _selectAll(List<ComicBase> comics) {
-    setState(() {
-      _selectedCids = comics.map((c) => c.uid).toSet();
-    });
-  }
-
-  void _invertSelection(List<ComicBase> comics) {
-    setState(() {
-      final allCids = comics.map((c) => c.uid).toSet();
-      _selectedCids = allCids.difference(_selectedCids);
-    });
-  }
-
-  Future<void> _batchDownload() async {
-    if (_selectedCids.isEmpty) return;
-
-    setState(() => _isDownloading = true);
-
-    final comics = _getFolderComicsHandler.state.data ?? [];
-    final selectedComics =
-        comics.where((c) => _selectedCids.contains(c.uid)).toList();
-
-    int successCount = 0;
-    int failCount = 0;
-
-    try {
-      final futures = selectedComics.map((comic) async {
-        try {
-          final chapters = await fetchChapters(comic.uid);
-          if (chapters.isEmpty) return false;
-
-          final downloadChapters = chapters
-              .map(
-                (chapter) => DownloadChapter(
-                  id: chapter.uid,
-                  title: chapter.title,
-                  order: chapter.order,
-                ),
-              )
-              .toList();
-
-          BackgroundDownloader.addTask(
-            ComicDownloadTask(
-              comic: DownloadComic(
-                id: comic.uid,
-                title: comic.title,
-                cover: comic.thumb.url,
-              ),
-              chapters: downloadChapters,
-            ),
-          );
-          return true;
-        } catch (e) {
-          Log.e('Batch download comic failed: ${comic.title}', error: e);
-          return false;
-        }
-      }).toList();
-
-      final results = await Future.wait(futures);
-      successCount = results.where((r) => r).length;
-      failCount = results.where((r) => !r).length;
-    } catch (e) {
-      Log.e('Batch download error', error: e);
-    }
-
-    if (mounted) {
-      if (failCount == 0) {
-        Toast.show(message: '已添加 $successCount 个下载任务');
-      } else {
-        Toast.show(message: '成功 $successCount 个，失败 $failCount 个');
-      }
-      setState(() {
-        _isSelecting = false;
-        _selectedCids.clear();
-        _isDownloading = false;
-      });
-    }
-  }
-
   void _openSearch() {
-    _exitSelectionMode();
     setState(() => _isSearching = true);
     _searchFocusNode.requestFocus();
   }
@@ -275,7 +164,7 @@ class _FolderComicsState extends State<FolderComics> with RequestMixin {
     }).toList();
   }
 
-  Widget _header(BuildContext context, List<ComicBase> allComics) {
+  Widget _header(BuildContext context) {
     return Padding(
       padding: const .symmetric(horizontal: 8, vertical: 4),
       child: _isSearching
@@ -313,48 +202,21 @@ class _FolderComicsState extends State<FolderComics> with RequestMixin {
                 ),
               ],
             )
-          : _isSelecting
-              ? Row(
-                  spacing: 5,
-                  children: [
-                    IconButton(
-                      icon: const Icon(Icons.close),
-                      tooltip: '关闭',
-                      onPressed: _exitSelectionMode,
-                    ),
-                    Expanded(
-                      child: Text(
-                        '已选 ${_selectedCids.length} 项',
-                        style: context.textTheme.titleMedium,
-                      ),
-                    ),
-                    IconButton(
-                      icon: const Icon(Icons.select_all),
-                      tooltip: '全选',
-                      onPressed: () => _selectAll(allComics),
-                    ),
-                    IconButton(
-                      icon: const Icon(Icons.repeat),
-                      tooltip: '反选',
-                      onPressed: () => _invertSelection(allComics),
-                    ),
-                  ],
-                )
-              : Row(
-                  spacing: 5,
-                  children: [
-                    Text(
-                      '收藏夹:${widget.folder?.name ?? '全部'}',
-                      style: context.textTheme.titleMedium,
-                    ),
-                    const Spacer(),
-                    IconButton(
-                      icon: const Icon(Icons.search),
-                      tooltip: '搜索',
-                      onPressed: _openSearch,
-                    ),
-                  ],
+          : Row(
+              spacing: 5,
+              children: [
+                Text(
+                  '收藏夹:${widget.folder?.name ?? '全部'}',
+                  style: context.textTheme.titleMedium,
                 ),
+                const Spacer(),
+                IconButton(
+                  icon: const Icon(Icons.search),
+                  tooltip: '搜索',
+                  onPressed: _openSearch,
+                ),
+              ],
+            ),
     );
   }
 
@@ -364,56 +226,21 @@ class _FolderComicsState extends State<FolderComics> with RequestMixin {
       Success(:final data) => () {
         if (data.isEmpty) return const Empty();
 
-        if (_keyword != _lastKeyword) {
-          _lastKeyword = _keyword;
-          _cachedFiltered = _filterComics(data);
-        }
-        final filtered = _cachedFiltered;
-
-        return Stack(
+        final filtered = _filterComics(data);
+        return Column(
           children: [
-            Column(
-              children: [
-                _header(context, filtered),
-                Expanded(
-                  child: filtered.isEmpty
-                      ? const Empty()
-                      : CommonTMIList(
-                          onItemSelected: widget.folder == null
-                              ? null
-                              : (key, comic) => _onItemSelected(key, comic),
-                          onItemLongPress: (comic) {
-                                  if (!_isSelecting) {
-                                    setState(() {
-                                      _isSelecting = true;
-                                      _selectedCids = {comic.uid};
-                                    });
-                                  }
-                                },
-                          contextMenu: widget.folder == null ? null : menu,
-                          enableDefaultGestures: !_isSelecting,
-                          comics: filtered,
-                          selectedCids: _isSelecting ? _selectedCids : null,
-                        ),
-                ),
-              ],
+            _header(context),
+            Expanded(
+              child: filtered.isEmpty
+                  ? const Empty()
+                  : CommonTMIList(
+                      onItemSelected: widget.folder == null
+                          ? null
+                          : _onItemSelected,
+                      contextMenu: widget.folder == null ? null : menu,
+                      comics: filtered,
+                    ),
             ),
-            if (_isSelecting && _selectedCids.isNotEmpty)
-              Positioned(
-                bottom: 16,
-                left: 16,
-                right: 16,
-                child: FilledButton(
-                  onPressed: _isDownloading ? null : _batchDownload,
-                  child: _isDownloading
-                      ? const SizedBox(
-                          height: 20,
-                          width: 20,
-                          child: CircularProgressIndicator(strokeWidth: 2),
-                        )
-                      : Text('批量下载(${_selectedCids.length})'),
-                ),
-              ),
           ],
         );
       }(),

--- a/lib/views/local_favorites/folder_comics.dart
+++ b/lib/views/local_favorites/folder_comics.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_context_menu/flutter_context_menu.dart';
 import 'package:haka_comic/database/local_favorites_helper.dart';
+import 'package:haka_comic/mixin/batch_select.dart';
 import 'package:haka_comic/network/models.dart';
 import 'package:haka_comic/utils/common.dart';
 import 'package:haka_comic/utils/extension.dart';
@@ -21,7 +22,7 @@ class FolderComics extends StatefulWidget {
   State<FolderComics> createState() => _FolderComicsState();
 }
 
-class _FolderComicsState extends State<FolderComics> with RequestMixin {
+class _FolderComicsState extends State<FolderComics> with RequestMixin, BatchSelectMixin {
   final _helper = LocalFavoritesHelper();
   final _searchController = TextEditingController();
   final _searchFocusNode = FocusNode();
@@ -114,6 +115,7 @@ class _FolderComicsState extends State<FolderComics> with RequestMixin {
   didUpdateWidget(covariant FolderComics oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.folder?.id != oldWidget.folder?.id) {
+      exitSelectionMode();
       _getFolderComicsHandler.run(widget.folder?.id);
     }
   }
@@ -126,6 +128,7 @@ class _FolderComicsState extends State<FolderComics> with RequestMixin {
   }
 
   void _openSearch() {
+    exitSelectionMode();
     setState(() => _isSearching = true);
     _searchFocusNode.requestFocus();
   }
@@ -227,20 +230,47 @@ class _FolderComicsState extends State<FolderComics> with RequestMixin {
         if (data.isEmpty) return const Empty();
 
         final filtered = _filterComics(data);
-        return Column(
+        return Stack(
           children: [
-            _header(context),
-            Expanded(
-              child: filtered.isEmpty
-                  ? const Empty()
-                  : CommonTMIList(
-                      onItemSelected: widget.folder == null
-                          ? null
-                          : _onItemSelected,
-                      contextMenu: widget.folder == null ? null : menu,
-                      comics: filtered,
-                    ),
+            Column(
+              children: [
+                _header(context),
+                Expanded(
+                  child: filtered.isEmpty
+                      ? const Empty()
+                      : CommonTMIList(
+                          onItemSelected: widget.folder == null
+                              ? null
+                              : (key, comic) => isSelecting
+                                  ? toggleItem(comic.uid)
+                                  : _onItemSelected(key, comic),
+                          onItemLongPress: (comic) {
+                            if (!isSelecting) enterSelectionMode(comic.uid);
+                          },
+                          contextMenu: widget.folder == null || isSelecting ? null : menu,
+                          enableDefaultGestures: !isSelecting,
+                          comics: filtered,
+                          selectedCids: isSelecting ? selectedCids : null,
+                        ),
+                ),
+              ],
             ),
+            if (isSelecting && selectedCids.isNotEmpty)
+              Positioned(
+                bottom: 16,
+                left: 16,
+                right: 16,
+                child: FilledButton(
+                  onPressed: isDownloading ? null : () => batchDownload(filtered),
+                  child: isDownloading
+                      ? const SizedBox(
+                          height: 20,
+                          width: 20,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : Text('批量下载(${selectedCids.length})'),
+                ),
+              ),
           ],
         );
       }(),

--- a/lib/views/local_favorites/folder_comics.dart
+++ b/lib/views/local_favorites/folder_comics.dart
@@ -382,9 +382,7 @@ class _FolderComicsState extends State<FolderComics> with RequestMixin {
                           onItemSelected: widget.folder == null
                               ? null
                               : (key, comic) => _onItemSelected(key, comic),
-                          onItemLongPress: widget.folder == null
-                              ? null
-                              : (comic) {
+                          onItemLongPress: (comic) {
                                   if (!_isSelecting) {
                                     setState(() {
                                       _isSelecting = true;

--- a/lib/views/local_favorites/folder_comics.dart
+++ b/lib/views/local_favorites/folder_comics.dart
@@ -30,6 +30,8 @@ class _FolderComicsState extends State<FolderComics> with RequestMixin {
 
   bool _isSearching = false;
   String _keyword = '';
+  String _lastKeyword = '';
+  List<ComicBase> _cachedFiltered = [];
   
   bool _isSelecting = false;
   Set<String> _selectedCids = {};
@@ -91,7 +93,7 @@ class _FolderComicsState extends State<FolderComics> with RequestMixin {
 
   late final menu = ContextMenu(entries: entries, padding: const .all(8.0));
 
-  void _onItemSelected(dynamic key, ComicBase item) async {
+  void _onItemSelected(dynamic key, ComicBase item) {
     if (_isSelecting) {
       setState(() {
         if (_selectedCids.contains(item.uid)) {
@@ -106,7 +108,7 @@ class _FolderComicsState extends State<FolderComics> with RequestMixin {
     switch (key) {
       case 'copy':
         final title = item.title;
-        await Clipboard.setData(ClipboardData(text: title));
+        Clipboard.setData(ClipboardData(text: title));
         Toast.show(message: '已复制');
         break;
       case 'delete':
@@ -131,6 +133,11 @@ class _FolderComicsState extends State<FolderComics> with RequestMixin {
   didUpdateWidget(covariant FolderComics oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.folder?.id != oldWidget.folder?.id) {
+      _lastKeyword = '';
+      _cachedFiltered = [];
+      _selectedCids.clear();
+      _isSelecting = false;
+      _isDownloading = false;
       _getFolderComicsHandler.run(widget.folder?.id);
     }
   }
@@ -140,10 +147,6 @@ class _FolderComicsState extends State<FolderComics> with RequestMixin {
     _searchController.dispose();
     _searchFocusNode.dispose();
     super.dispose();
-  }
-
-  void _enterSelectionMode() {
-    setState(() => _isSelecting = true);
   }
 
   void _exitSelectionMode() {
@@ -159,10 +162,6 @@ class _FolderComicsState extends State<FolderComics> with RequestMixin {
     });
   }
 
-  void _deselectAll() {
-    setState(() => _selectedCids.clear());
-  }
-
   void _invertSelection(List<ComicBase> comics) {
     setState(() {
       final allCids = comics.map((c) => c.uid).toSet();
@@ -172,32 +171,32 @@ class _FolderComicsState extends State<FolderComics> with RequestMixin {
 
   Future<void> _batchDownload() async {
     if (_selectedCids.isEmpty) return;
-    
+
     setState(() => _isDownloading = true);
-    
+
     final comics = _getFolderComicsHandler.state.data ?? [];
-    final selectedComics = comics.where((c) => _selectedCids.contains(c.uid)).toList();
-    
+    final selectedComics =
+        comics.where((c) => _selectedCids.contains(c.uid)).toList();
+
     int successCount = 0;
     int failCount = 0;
-    
+
     try {
-      for (var comic in selectedComics) {
+      final futures = selectedComics.map((comic) async {
         try {
           final chapters = await fetchChapters(comic.uid);
-          if (chapters.isEmpty) {
-            failCount++;
-            continue;
-          }
-          
+          if (chapters.isEmpty) return false;
+
           final downloadChapters = chapters
-              .map((chapter) => DownloadChapter(
-                id: chapter.uid,
-                title: chapter.title,
-                order: chapter.order,
-              ))
+              .map(
+                (chapter) => DownloadChapter(
+                  id: chapter.uid,
+                  title: chapter.title,
+                  order: chapter.order,
+                ),
+              )
               .toList();
-          
+
           BackgroundDownloader.addTask(
             ComicDownloadTask(
               comic: DownloadComic(
@@ -208,36 +207,36 @@ class _FolderComicsState extends State<FolderComics> with RequestMixin {
               chapters: downloadChapters,
             ),
           );
-          
-          successCount++;
+          return true;
         } catch (e) {
-          Log.e('Batch download comic failed', error: e);
-          failCount++;
+          Log.e('Batch download comic failed: ${comic.title}', error: e);
+          return false;
         }
-      }
-      
-      if (mounted) {
-        if (failCount == 0) {
-          Toast.show(message: '已添加 $successCount 个下载任务');
-        } else {
-          Toast.show(message: '成功 $successCount 个，失败 $failCount 个');
-        }
-        setState(() {
-          _isSelecting = false;
-          _selectedCids.clear();
-          _isDownloading = false;
-        });
-      }
+      }).toList();
+
+      final results = await Future.wait(futures);
+      successCount = results.where((r) => r).length;
+      failCount = results.where((r) => !r).length;
     } catch (e) {
       Log.e('Batch download error', error: e);
-      Toast.show(message: '批量下载失败');
-      if (mounted) {
-        setState(() => _isDownloading = false);
+    }
+
+    if (mounted) {
+      if (failCount == 0) {
+        Toast.show(message: '已添加 $successCount 个下载任务');
+      } else {
+        Toast.show(message: '成功 $successCount 个，失败 $failCount 个');
       }
+      setState(() {
+        _isSelecting = false;
+        _selectedCids.clear();
+        _isDownloading = false;
+      });
     }
   }
 
   void _openSearch() {
+    _exitSelectionMode();
     setState(() => _isSearching = true);
     _searchFocusNode.requestFocus();
   }
@@ -365,59 +364,64 @@ class _FolderComicsState extends State<FolderComics> with RequestMixin {
       Success(:final data) => () {
         if (data.isEmpty) return const Empty();
 
-        final filtered = _filterComics(data);
-        
-        return Scaffold(
-          body: Column(
-            children: [
-              _header(context, filtered),
-              Expanded(
-                child: filtered.isEmpty
-                    ? const Empty()
-                    : CommonTMIList(
-                        onItemSelected: widget.folder == null
-                            ? null
-                            : (key, comic) {
-                                if (_isSelecting) {
-                                  _onItemSelected(null, comic);
-                                } else {
-                                  _onItemSelected(key, comic);
-                                }
-                              },
-                        onItemLongPress: widget.folder == null
-                            ? null
-                            : (comic) {
-                                if (!_isSelecting) {
-                                  setState(() {
-                                    _isSelecting = true;
-                                    _selectedCids = {comic.uid};
-                                  });
-                                }
-                              },
-                        contextMenu: _isSelecting ? null : (widget.folder == null ? null : menu),
-                        comics: filtered,
-                        selectedCids: _isSelecting ? _selectedCids : null,
-                      ),
+        if (_keyword != _lastKeyword) {
+          _lastKeyword = _keyword;
+          _cachedFiltered = _filterComics(data);
+        }
+        final filtered = _cachedFiltered;
+
+        return Stack(
+          children: [
+            Column(
+              children: [
+                _header(context, filtered),
+                Expanded(
+                  child: filtered.isEmpty
+                      ? const Empty()
+                      : CommonTMIList(
+                          onItemSelected: widget.folder == null
+                              ? null
+                              : (key, comic) {
+                                  if (_isSelecting) {
+                                    _onItemSelected(null, comic);
+                                  } else {
+                                    _onItemSelected(key, comic);
+                                  }
+                                },
+                          onItemLongPress: widget.folder == null
+                              ? null
+                              : (comic) {
+                                  if (!_isSelecting) {
+                                    setState(() {
+                                      _isSelecting = true;
+                                      _selectedCids = {comic.uid};
+                                    });
+                                  }
+                                },
+                          contextMenu: _isSelecting ? null : (widget.folder == null ? null : menu),
+                          comics: filtered,
+                          selectedCids: _isSelecting ? _selectedCids : null,
+                        ),
+                ),
+              ],
+            ),
+            if (_isSelecting && _selectedCids.isNotEmpty)
+              Positioned(
+                bottom: 16,
+                left: 16,
+                right: 16,
+                child: FilledButton(
+                  onPressed: _isDownloading ? null : _batchDownload,
+                  child: _isDownloading
+                      ? const SizedBox(
+                          height: 20,
+                          width: 20,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : Text('批量下载(${_selectedCids.length})'),
+                ),
               ),
-            ],
-          ),
-          persistentFooterButtons: _isSelecting && _selectedCids.isNotEmpty
-              ? [
-                  SizedBox(
-                    width: double.infinity,
-                    child: FilledButton(
-                      onPressed: _isDownloading ? null : _batchDownload,
-                      child: _isDownloading
-                          ? const SizedBox(
-                              height: 20,
-                              width: 20,
-                              child: CircularProgressIndicator(strokeWidth: 2),
-                            )
-                          : Text('批量下载(${_selectedCids.length})'),
-                    ),
-                  ),
-                ]
-              : null,
+          ],
         );
       }(),
       Error(:final error) => ErrorPage(

--- a/lib/views/local_favorites/folder_comics.dart
+++ b/lib/views/local_favorites/folder_comics.dart
@@ -354,11 +354,6 @@ class _FolderComicsState extends State<FolderComics> with RequestMixin {
                       tooltip: '搜索',
                       onPressed: _openSearch,
                     ),
-                    IconButton(
-                      icon: const Icon(Icons.checklist_rtl),
-                      tooltip: '多选',
-                      onPressed: _enterSelectionMode,
-                    ),
                   ],
                 ),
     );
@@ -387,6 +382,16 @@ class _FolderComicsState extends State<FolderComics> with RequestMixin {
                                   _onItemSelected(null, comic);
                                 } else {
                                   _onItemSelected(key, comic);
+                                }
+                              },
+                        onItemLongPress: widget.folder == null
+                            ? null
+                            : (comic) {
+                                if (!_isSelecting) {
+                                  setState(() {
+                                    _isSelecting = true;
+                                    _selectedCids = {comic.uid};
+                                  });
                                 }
                               },
                         contextMenu: _isSelecting ? null : (widget.folder == null ? null : menu),

--- a/lib/views/local_favorites/folder_comics.dart
+++ b/lib/views/local_favorites/folder_comics.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_context_menu/flutter_context_menu.dart';
 import 'package:haka_comic/database/local_favorites_helper.dart';
-import 'package:haka_comic/mixin/batch_select.dart';
 import 'package:haka_comic/network/models.dart';
 import 'package:haka_comic/utils/common.dart';
 import 'package:haka_comic/utils/extension.dart';
@@ -22,7 +21,7 @@ class FolderComics extends StatefulWidget {
   State<FolderComics> createState() => _FolderComicsState();
 }
 
-class _FolderComicsState extends State<FolderComics> with RequestMixin, BatchSelectMixin {
+class _FolderComicsState extends State<FolderComics> with RequestMixin {
   final _helper = LocalFavoritesHelper();
   final _searchController = TextEditingController();
   final _searchFocusNode = FocusNode();
@@ -115,7 +114,6 @@ class _FolderComicsState extends State<FolderComics> with RequestMixin, BatchSel
   didUpdateWidget(covariant FolderComics oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.folder?.id != oldWidget.folder?.id) {
-      exitSelectionMode();
       _getFolderComicsHandler.run(widget.folder?.id);
     }
   }
@@ -128,7 +126,6 @@ class _FolderComicsState extends State<FolderComics> with RequestMixin, BatchSel
   }
 
   void _openSearch() {
-    exitSelectionMode();
     setState(() => _isSearching = true);
     _searchFocusNode.requestFocus();
   }
@@ -230,47 +227,20 @@ class _FolderComicsState extends State<FolderComics> with RequestMixin, BatchSel
         if (data.isEmpty) return const Empty();
 
         final filtered = _filterComics(data);
-        return Stack(
+        return Column(
           children: [
-            Column(
-              children: [
-                _header(context),
-                Expanded(
-                  child: filtered.isEmpty
-                      ? const Empty()
-                      : CommonTMIList(
-                          onItemSelected: widget.folder == null
-                              ? null
-                              : (key, comic) => isSelecting
-                                  ? toggleItem(comic.uid)
-                                  : _onItemSelected(key, comic),
-                          onItemLongPress: (comic) {
-                            if (!isSelecting) enterSelectionMode(comic.uid);
-                          },
-                          contextMenu: widget.folder == null || isSelecting ? null : menu,
-                          enableDefaultGestures: !isSelecting,
-                          comics: filtered,
-                          selectedCids: isSelecting ? selectedCids : null,
-                        ),
-                ),
-              ],
+            _header(context),
+            Expanded(
+              child: filtered.isEmpty
+                  ? const Empty()
+                  : CommonTMIList(
+                      onItemSelected: widget.folder == null
+                          ? null
+                          : _onItemSelected,
+                      contextMenu: widget.folder == null ? null : menu,
+                      comics: filtered,
+                    ),
             ),
-            if (isSelecting && selectedCids.isNotEmpty)
-              Positioned(
-                bottom: 16,
-                left: 16,
-                right: 16,
-                child: FilledButton(
-                  onPressed: isDownloading ? null : () => batchDownload(filtered),
-                  child: isDownloading
-                      ? const SizedBox(
-                          height: 20,
-                          width: 20,
-                          child: CircularProgressIndicator(strokeWidth: 2),
-                        )
-                      : Text('批量下载(${selectedCids.length})'),
-                ),
-              ),
           ],
         );
       }(),

--- a/lib/views/local_favorites/folder_comics.dart
+++ b/lib/views/local_favorites/folder_comics.dart
@@ -381,13 +381,7 @@ class _FolderComicsState extends State<FolderComics> with RequestMixin {
                       : CommonTMIList(
                           onItemSelected: widget.folder == null
                               ? null
-                              : (key, comic) {
-                                  if (_isSelecting) {
-                                    _onItemSelected(null, comic);
-                                  } else {
-                                    _onItemSelected(key, comic);
-                                  }
-                                },
+                              : (key, comic) => _onItemSelected(key, comic),
                           onItemLongPress: widget.folder == null
                               ? null
                               : (comic) {
@@ -398,7 +392,8 @@ class _FolderComicsState extends State<FolderComics> with RequestMixin {
                                     });
                                   }
                                 },
-                          contextMenu: _isSelecting ? null : (widget.folder == null ? null : menu),
+                          contextMenu: widget.folder == null ? null : menu,
+                          enableDefaultGestures: !_isSelecting,
                           comics: filtered,
                           selectedCids: _isSelecting ? _selectedCids : null,
                         ),

--- a/lib/views/mine/favorites.dart
+++ b/lib/views/mine/favorites.dart
@@ -163,7 +163,7 @@ class _FavoritesState extends State<Favorites>
     }
   }
 
-  List<Widget> _buildAppBarActions(BuildContext context, List<ComicBase> comics) {
+  List<Widget> _buildAppBarActions(List<ComicBase> comics) {
     if (_isSelecting) {
       return [
         IconButton(
@@ -241,7 +241,7 @@ class _FavoritesState extends State<Favorites>
             title: _isSelecting
                 ? Text('已选 ${_selectedCids.length} 项')
                 : const Text('收藏漫画'),
-            actions: _buildAppBarActions(context, comics),
+            actions: _buildAppBarActions(comics),
           ),
           body: Stack(
             children: [

--- a/lib/views/mine/favorites.dart
+++ b/lib/views/mine/favorites.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:haka_comic/mixin/batch_select.dart';
 import 'package:haka_comic/mixin/pagination.dart';
 import 'package:haka_comic/network/http.dart';
 import 'package:haka_comic/network/models.dart';
@@ -9,9 +10,7 @@ import 'package:haka_comic/utils/request/request.dart';
 import 'package:haka_comic/views/comics/common_pagination_footer.dart';
 import 'package:haka_comic/views/comics/common_tmi_list.dart';
 import 'package:haka_comic/views/comics/page_selector.dart';
-import 'package:haka_comic/views/download/background_downloader.dart';
 import 'package:haka_comic/widgets/error_page.dart';
-import 'package:haka_comic/widgets/toast.dart';
 
 class Favorites extends StatefulWidget {
   const Favorites({super.key});
@@ -21,13 +20,9 @@ class Favorites extends StatefulWidget {
 }
 
 class _FavoritesState extends State<Favorites>
-    with RequestMixin, PaginationMixin {
+    with RequestMixin, PaginationMixin, BatchSelectMixin {
   int _page = 1;
   ComicSortType _sortType = ComicSortType.dd;
-
-  bool _isSelecting = false;
-  Set<String> _selectedCids = {};
-  bool _isDownloading = false;
 
   late final _handler = fetchFavoriteComics.useRequest(
     defaultParams: UserFavoritePayload(page: _page, sort: _sortType),
@@ -60,8 +55,8 @@ class _FavoritesState extends State<Favorites>
   Future<void> _onPageChange(int page) async {
     setState(() {
       _page = page;
-      _isSelecting = false;
-      _selectedCids = {};
+      isSelecting = false;
+      selectedCids = {};
     });
     await _handler.run(UserFavoritePayload(page: page, sort: _sortType));
   }
@@ -71,115 +66,30 @@ class _FavoritesState extends State<Favorites>
     setState(() {
       _page = 1;
       _sortType = sortType;
-      _isSelecting = false;
-      _selectedCids = {};
+      isSelecting = false;
+      selectedCids = {};
     });
     _handler.mutate(ComicsResponse.empty);
     _handler.run(UserFavoritePayload(page: 1, sort: sortType));
   }
 
-  void _exitSelectionMode() {
-    setState(() {
-      _isSelecting = false;
-      _selectedCids = {};
-    });
-  }
-
-  void _selectAll(List<ComicBase> comics) {
-    setState(() {
-      _selectedCids = comics.map((c) => c.uid).toSet();
-    });
-  }
-
-  void _invertSelection(List<ComicBase> comics) {
-    setState(() {
-      final allCids = comics.map((c) => c.uid).toSet();
-      _selectedCids = allCids.difference(_selectedCids);
-    });
-  }
-
-  Future<void> _batchDownload(List<ComicBase> allComics) async {
-    if (_selectedCids.isEmpty) return;
-
-    setState(() => _isDownloading = true);
-
-    final selectedComics =
-        allComics.where((c) => _selectedCids.contains(c.uid)).toList();
-
-    int successCount = 0;
-    int failCount = 0;
-
-    try {
-      final futures = selectedComics.map((comic) async {
-        try {
-          final chapters = await fetchChapters(comic.uid);
-          if (chapters.isEmpty) return false;
-
-          final downloadChapters = chapters
-              .map(
-                (chapter) => DownloadChapter(
-                  id: chapter.uid,
-                  title: chapter.title,
-                  order: chapter.order,
-                ),
-              )
-              .toList();
-
-          BackgroundDownloader.addTask(
-            ComicDownloadTask(
-              comic: DownloadComic(
-                id: comic.uid,
-                title: comic.title,
-                cover: comic.thumb.url,
-              ),
-              chapters: downloadChapters,
-            ),
-          );
-          return true;
-        } catch (e) {
-          Log.e('Batch download comic failed: ${comic.title}', error: e);
-          return false;
-        }
-      }).toList();
-
-      final results = await Future.wait(futures);
-      successCount = results.where((r) => r).length;
-      failCount = results.where((r) => !r).length;
-    } catch (e) {
-      Log.e('Batch download error', error: e);
-    }
-
-    if (mounted) {
-      if (failCount == 0) {
-        Toast.show(message: '已添加 $successCount 个下载任务');
-      } else {
-        Toast.show(message: '成功 $successCount 个，失败 $failCount 个');
-      }
-      setState(() {
-        _isSelecting = false;
-        _selectedCids = {};
-        _isDownloading = false;
-      });
-    }
-  }
-
   List<Widget> _buildAppBarActions(List<ComicBase> comics) {
-    if (_isSelecting) {
+    if (isSelecting) {
       return [
         IconButton(
           icon: const Icon(Icons.close),
           tooltip: '退出选择',
-          onPressed: _exitSelectionMode,
+          onPressed: exitSelectionMode,
         ),
         IconButton(
           icon: const Icon(Icons.select_all),
           tooltip: '全选',
-          onPressed: () => _selectAll(comics),
+          onPressed: () => selectAll(comics),
         ),
         IconButton(
           icon: const Icon(Icons.repeat),
           tooltip: '反选',
-          onPressed: () => _invertSelection(comics),
+          onPressed: () => invertSelection(comics),
         ),
       ];
     }
@@ -192,7 +102,7 @@ class _FavoritesState extends State<Favorites>
             {'label': '旧到新', 'type': ComicSortType.da},
           ].map(
             (e) => MenuItemButton(
-              onPressed: _isDownloading
+              onPressed: isDownloading
                   ? null
                   : () {
                       _onSortChange(e['type'] as ComicSortType);
@@ -238,8 +148,8 @@ class _FavoritesState extends State<Favorites>
 
         return Scaffold(
           appBar: AppBar(
-            title: _isSelecting
-                ? Text('已选 ${_selectedCids.length} 项')
+            title: isSelecting
+                ? Text('已选 ${selectedCids.length} 项')
                 : const Text('收藏漫画'),
             actions: _buildAppBarActions(comics),
           ),
@@ -248,33 +158,20 @@ class _FavoritesState extends State<Favorites>
               switch (_handler.state) {
                 RequestState(:final data) when data != null => CommonTMIList(
                   comics: data.comics.docs,
-                  selectedCids: _isSelecting ? _selectedCids : null,
+                  selectedCids: isSelecting ? selectedCids : null,
                   onItemLongPress: (comic) {
-                    if (!_isSelecting) {
-                      setState(() {
-                        _isSelecting = true;
-                        _selectedCids = {comic.uid};
-                      });
-                    }
+                    if (!isSelecting) enterSelectionMode(comic.uid);
                   },
-                  onItemSelected: _isSelecting
-                      ? (key, comic) {
-                          setState(() {
-                            if (_selectedCids.contains(comic.uid)) {
-                              _selectedCids.remove(comic.uid);
-                            } else {
-                              _selectedCids.add(comic.uid);
-                            }
-                          });
-                        }
+                  onItemSelected: isSelecting
+                      ? (_, comic) => toggleItem(comic.uid)
                       : null,
-                  enableDefaultGestures: !_isSelecting,
+                  enableDefaultGestures: !isSelecting,
                   pageSelectorBuilder: pagination
                       ? (context) {
                           return PageSelector(
                             currentPage: _page,
                             pages: data.comics.pages,
-                            onPageChange: _isDownloading
+                            onPageChange: isDownloading
                                 ? (_) async {}
                                 : _onPageChange,
                           );
@@ -294,20 +191,20 @@ class _FavoritesState extends State<Favorites>
                 ),
                 _ => const Center(child: CircularProgressIndicator()),
               },
-              if (_isSelecting && _selectedCids.isNotEmpty)
+              if (isSelecting && selectedCids.isNotEmpty)
                 Positioned(
                   bottom: 16,
                   left: 16,
                   right: 16,
                   child: FilledButton(
-                    onPressed: _isDownloading ? null : () => _batchDownload(comics),
-                    child: _isDownloading
+                    onPressed: isDownloading ? null : () => batchDownload(comics),
+                    child: isDownloading
                         ? const SizedBox(
                             height: 20,
                             width: 20,
                             child: CircularProgressIndicator(strokeWidth: 2),
                           )
-                        : Text('批量下载(${_selectedCids.length})'),
+                        : Text('批量下载(${selectedCids.length})'),
                   ),
                 ),
             ],

--- a/lib/views/mine/favorites.dart
+++ b/lib/views/mine/favorites.dart
@@ -73,72 +73,6 @@ class _FavoritesState extends State<Favorites>
     _handler.run(UserFavoritePayload(page: 1, sort: sortType));
   }
 
-  List<Widget> _buildAppBarActions(List<ComicBase> comics) {
-    if (isSelecting) {
-      return [
-        IconButton(
-          icon: const Icon(Icons.close),
-          tooltip: '退出选择',
-          onPressed: exitSelectionMode,
-        ),
-        IconButton(
-          icon: const Icon(Icons.select_all),
-          tooltip: '全选',
-          onPressed: () => selectAll(comics),
-        ),
-        IconButton(
-          icon: const Icon(Icons.repeat),
-          tooltip: '反选',
-          onPressed: () => invertSelection(comics),
-        ),
-      ];
-    }
-
-    return [
-      MenuAnchor(
-        menuChildren: <Widget>[
-          ...[
-            {'label': '新到旧', 'type': ComicSortType.dd},
-            {'label': '旧到新', 'type': ComicSortType.da},
-          ].map(
-            (e) => MenuItemButton(
-              onPressed: isDownloading
-                  ? null
-                  : () {
-                      _onSortChange(e['type'] as ComicSortType);
-                    },
-              child: Row(
-                spacing: 5,
-                children: [
-                  Text(e['label'] as String),
-                  if (_sortType == e['type'])
-                    Icon(
-                      Icons.done,
-                      size: 16,
-                      color: context.colorScheme.primary,
-                    ),
-                ],
-              ),
-            ),
-          ),
-        ],
-        builder: (_, MenuController controller, Widget? child) {
-          return IconButton(
-            onPressed: () {
-              if (controller.isOpen) {
-                controller.close();
-              } else {
-                controller.open();
-              }
-            },
-            icon: const Icon(Icons.sort),
-            tooltip: '排序',
-          );
-        },
-      ),
-    ];
-  }
-
   @override
   Widget build(BuildContext context) {
     return RouteAwarePageWrapper(
@@ -147,12 +81,18 @@ class _FavoritesState extends State<Favorites>
         final comics = data?.comics.docs ?? [];
 
         return Scaffold(
-          appBar: AppBar(
-            title: isSelecting
-                ? Text('已选 ${selectedCids.length} 项')
-                : const Text('收藏漫画'),
-            actions: _buildAppBarActions(comics),
-          ),
+          appBar: isSelecting
+              ? _SelectionAppBar(
+                  count: selectedCids.length,
+                  onExit: exitSelectionMode,
+                  onSelectAll: () => selectAll(comics),
+                  onInvert: () => invertSelection(comics),
+                )
+              : _NormalAppBar(
+                  sortType: _sortType,
+                  isDownloading: isDownloading,
+                  onSortChange: _onSortChange,
+                ),
           body: Stack(
             children: [
               switch (_handler.state) {
@@ -211,6 +151,93 @@ class _FavoritesState extends State<Favorites>
           ),
         );
       },
+    );
+  }
+}
+
+class _SelectionAppBar extends StatelessWidget implements PreferredSizeWidget {
+  const _SelectionAppBar({
+    required this.count,
+    required this.onExit,
+    required this.onSelectAll,
+    required this.onInvert,
+  });
+
+  final int count;
+  final VoidCallback onExit;
+  final VoidCallback onSelectAll;
+  final VoidCallback onInvert;
+
+  @override
+  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBar(
+      title: Text('已选 $count 项'),
+      leading: IconButton(
+        icon: const Icon(Icons.close),
+        tooltip: '退出选择',
+        onPressed: onExit,
+      ),
+      automaticallyImplyLeading: false,
+      actions: [
+        IconButton(
+          icon: const Icon(Icons.select_all),
+          tooltip: '全选',
+          onPressed: onSelectAll,
+        ),
+        IconButton(
+          icon: const Icon(Icons.repeat),
+          tooltip: '反选',
+          onPressed: onInvert,
+        ),
+      ],
+    );
+  }
+}
+
+class _NormalAppBar extends StatelessWidget implements PreferredSizeWidget {
+  const _NormalAppBar({
+    required this.sortType,
+    required this.isDownloading,
+    required this.onSortChange,
+  });
+
+  final ComicSortType sortType;
+  final bool isDownloading;
+  final void Function(ComicSortType) onSortChange;
+
+  @override
+  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBar(
+      title: const Text('收藏漫画'),
+      actions: [
+        MenuAnchor(
+          menuChildren: [
+            {'label': '新到旧', 'type': ComicSortType.dd},
+            {'label': '旧到新', 'type': ComicSortType.da},
+          ].map((e) => MenuItemButton(
+            onPressed: isDownloading ? null : () => onSortChange(e['type'] as ComicSortType),
+            child: Row(
+              spacing: 5,
+              children: [
+                Text(e['label'] as String),
+                if (sortType == e['type'])
+                  Icon(Icons.done, size: 16, color: context.colorScheme.primary),
+              ],
+            ),
+          )).toList(),
+          builder: (_, controller, _) => IconButton(
+            icon: const Icon(Icons.sort),
+            tooltip: '排序',
+            onPressed: () => controller.isOpen ? controller.close() : controller.open(),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/views/mine/favorites.dart
+++ b/lib/views/mine/favorites.dart
@@ -9,7 +9,9 @@ import 'package:haka_comic/utils/request/request.dart';
 import 'package:haka_comic/views/comics/common_pagination_footer.dart';
 import 'package:haka_comic/views/comics/common_tmi_list.dart';
 import 'package:haka_comic/views/comics/page_selector.dart';
+import 'package:haka_comic/views/download/background_downloader.dart';
 import 'package:haka_comic/widgets/error_page.dart';
+import 'package:haka_comic/widgets/toast.dart';
 
 class Favorites extends StatefulWidget {
   const Favorites({super.key});
@@ -22,6 +24,10 @@ class _FavoritesState extends State<Favorites>
     with RequestMixin, PaginationMixin {
   int _page = 1;
   ComicSortType _sortType = ComicSortType.dd;
+
+  bool _isSelecting = false;
+  Set<String> _selectedCids = {};
+  bool _isDownloading = false;
 
   late final _handler = fetchFavoriteComics.useRequest(
     defaultParams: UserFavoritePayload(page: _page, sort: _sortType),
@@ -54,6 +60,8 @@ class _FavoritesState extends State<Favorites>
   Future<void> _onPageChange(int page) async {
     setState(() {
       _page = page;
+      _isSelecting = false;
+      _selectedCids = {};
     });
     await _handler.run(UserFavoritePayload(page: page, sort: _sortType));
   }
@@ -63,86 +71,247 @@ class _FavoritesState extends State<Favorites>
     setState(() {
       _page = 1;
       _sortType = sortType;
+      _isSelecting = false;
+      _selectedCids = {};
     });
     _handler.mutate(ComicsResponse.empty);
     _handler.run(UserFavoritePayload(page: 1, sort: sortType));
+  }
+
+  void _exitSelectionMode() {
+    setState(() {
+      _isSelecting = false;
+      _selectedCids = {};
+    });
+  }
+
+  void _selectAll(List<ComicBase> comics) {
+    setState(() {
+      _selectedCids = comics.map((c) => c.uid).toSet();
+    });
+  }
+
+  void _invertSelection(List<ComicBase> comics) {
+    setState(() {
+      final allCids = comics.map((c) => c.uid).toSet();
+      _selectedCids = allCids.difference(_selectedCids);
+    });
+  }
+
+  Future<void> _batchDownload(List<ComicBase> allComics) async {
+    if (_selectedCids.isEmpty) return;
+
+    setState(() => _isDownloading = true);
+
+    final selectedComics =
+        allComics.where((c) => _selectedCids.contains(c.uid)).toList();
+
+    int successCount = 0;
+    int failCount = 0;
+
+    try {
+      final futures = selectedComics.map((comic) async {
+        try {
+          final chapters = await fetchChapters(comic.uid);
+          if (chapters.isEmpty) return false;
+
+          final downloadChapters = chapters
+              .map(
+                (chapter) => DownloadChapter(
+                  id: chapter.uid,
+                  title: chapter.title,
+                  order: chapter.order,
+                ),
+              )
+              .toList();
+
+          BackgroundDownloader.addTask(
+            ComicDownloadTask(
+              comic: DownloadComic(
+                id: comic.uid,
+                title: comic.title,
+                cover: comic.thumb.url,
+              ),
+              chapters: downloadChapters,
+            ),
+          );
+          return true;
+        } catch (e) {
+          Log.e('Batch download comic failed: ${comic.title}', error: e);
+          return false;
+        }
+      }).toList();
+
+      final results = await Future.wait(futures);
+      successCount = results.where((r) => r).length;
+      failCount = results.where((r) => !r).length;
+    } catch (e) {
+      Log.e('Batch download error', error: e);
+    }
+
+    if (mounted) {
+      if (failCount == 0) {
+        Toast.show(message: '已添加 $successCount 个下载任务');
+      } else {
+        Toast.show(message: '成功 $successCount 个，失败 $failCount 个');
+      }
+      setState(() {
+        _isSelecting = false;
+        _selectedCids = {};
+        _isDownloading = false;
+      });
+    }
+  }
+
+  List<Widget> _buildAppBarActions(BuildContext context, List<ComicBase> comics) {
+    if (_isSelecting) {
+      return [
+        IconButton(
+          icon: const Icon(Icons.close),
+          tooltip: '退出选择',
+          onPressed: _exitSelectionMode,
+        ),
+        IconButton(
+          icon: const Icon(Icons.select_all),
+          tooltip: '全选',
+          onPressed: () => _selectAll(comics),
+        ),
+        IconButton(
+          icon: const Icon(Icons.repeat),
+          tooltip: '反选',
+          onPressed: () => _invertSelection(comics),
+        ),
+      ];
+    }
+
+    return [
+      MenuAnchor(
+        menuChildren: <Widget>[
+          ...[
+            {'label': '新到旧', 'type': ComicSortType.dd},
+            {'label': '旧到新', 'type': ComicSortType.da},
+          ].map(
+            (e) => MenuItemButton(
+              onPressed: _isDownloading
+                  ? null
+                  : () {
+                      _onSortChange(e['type'] as ComicSortType);
+                    },
+              child: Row(
+                spacing: 5,
+                children: [
+                  Text(e['label'] as String),
+                  if (_sortType == e['type'])
+                    Icon(
+                      Icons.done,
+                      size: 16,
+                      color: context.colorScheme.primary,
+                    ),
+                ],
+              ),
+            ),
+          ),
+        ],
+        builder: (_, MenuController controller, Widget? child) {
+          return IconButton(
+            onPressed: () {
+              if (controller.isOpen) {
+                controller.close();
+              } else {
+                controller.open();
+              }
+            },
+            icon: const Icon(Icons.sort),
+            tooltip: '排序',
+          );
+        },
+      ),
+    ];
   }
 
   @override
   Widget build(BuildContext context) {
     return RouteAwarePageWrapper(
       builder: (context, completed) {
+        final data = _handler.state.data;
+        final comics = data?.comics.docs ?? [];
+
         return Scaffold(
           appBar: AppBar(
-            title: const Text('收藏漫画'),
-            actions: [
-              MenuAnchor(
-                menuChildren: <Widget>[
-                  ...[
-                    {'label': '新到旧', 'type': ComicSortType.dd},
-                    {'label': '旧到新', 'type': ComicSortType.da},
-                  ].map(
-                    (e) => MenuItemButton(
-                      onPressed: () {
-                        _onSortChange(e['type'] as ComicSortType);
-                      },
-                      child: Row(
-                        spacing: 5,
-                        children: [
-                          Text(e['label'] as String),
-                          if (_sortType == e['type'])
-                            Icon(
-                              Icons.done,
-                              size: 16,
-                              color: context.colorScheme.primary,
-                            ),
-                        ],
-                      ),
-                    ),
+            title: _isSelecting
+                ? Text('已选 ${_selectedCids.length} 项')
+                : const Text('收藏漫画'),
+            actions: _buildAppBarActions(context, comics),
+          ),
+          body: Stack(
+            children: [
+              switch (_handler.state) {
+                RequestState(:final data) when data != null => CommonTMIList(
+                  comics: data.comics.docs,
+                  selectedCids: _isSelecting ? _selectedCids : null,
+                  onItemLongPress: (comic) {
+                    if (!_isSelecting) {
+                      setState(() {
+                        _isSelecting = true;
+                        _selectedCids = {comic.uid};
+                      });
+                    }
+                  },
+                  onItemSelected: _isSelecting
+                      ? (key, comic) {
+                          setState(() {
+                            if (_selectedCids.contains(comic.uid)) {
+                              _selectedCids.remove(comic.uid);
+                            } else {
+                              _selectedCids.add(comic.uid);
+                            }
+                          });
+                        }
+                      : null,
+                  enableDefaultGestures: !_isSelecting,
+                  pageSelectorBuilder: pagination
+                      ? (context) {
+                          return PageSelector(
+                            currentPage: _page,
+                            pages: data.comics.pages,
+                            onPageChange: _isDownloading
+                                ? (_) async {}
+                                : _onPageChange,
+                          );
+                        }
+                      : null,
+                  controller: pagination ? null : scrollController,
+                  footerBuilder: pagination
+                      ? null
+                      : (context) {
+                          final loading = _handler.state.loading;
+                          return CommonPaginationFooter(loading: loading);
+                        },
+                ),
+                Error(:final error) => ErrorPage(
+                  errorMessage: error.toString(),
+                  onRetry: _handler.refresh,
+                ),
+                _ => const Center(child: CircularProgressIndicator()),
+              },
+              if (_isSelecting && _selectedCids.isNotEmpty)
+                Positioned(
+                  bottom: 16,
+                  left: 16,
+                  right: 16,
+                  child: FilledButton(
+                    onPressed: _isDownloading ? null : () => _batchDownload(comics),
+                    child: _isDownloading
+                        ? const SizedBox(
+                            height: 20,
+                            width: 20,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : Text('批量下载(${_selectedCids.length})'),
                   ),
-                ],
-                builder: (_, MenuController controller, Widget? child) {
-                  return IconButton(
-                    onPressed: () {
-                      if (controller.isOpen) {
-                        controller.close();
-                      } else {
-                        controller.open();
-                      }
-                    },
-                    icon: const Icon(Icons.sort),
-                    tooltip: '排序',
-                  );
-                },
-              ),
+                ),
             ],
           ),
-          body: switch (_handler.state) {
-            RequestState(:final data) when data != null => CommonTMIList(
-              comics: data.comics.docs,
-              pageSelectorBuilder: pagination
-                  ? (context) {
-                      return PageSelector(
-                        currentPage: _page,
-                        pages: data.comics.pages,
-                        onPageChange: _onPageChange,
-                      );
-                    }
-                  : null,
-              controller: pagination ? null : scrollController,
-              footerBuilder: pagination
-                  ? null
-                  : (context) {
-                      final loading = _handler.state.loading;
-                      return CommonPaginationFooter(loading: loading);
-                    },
-            ),
-            Error(:final error) => ErrorPage(
-              errorMessage: error.toString(),
-              onRetry: _handler.refresh,
-            ),
-            _ => const Center(child: CircularProgressIndicator()),
-          },
         );
       },
     );


### PR DESCRIPTION
---
  ## Description

  Add long-press multi-select and batch download to the online favorites page, with shared infrastructure extracted as a reusable
  mixin.

  Closes #111

  ## Reasoning

  The online favorites page had no way to bulk-download comics. This PR adds gesture-driven multi-select with batch download, and
  extracts the selection state machine into `BatchSelectMixin` for future reuse on other pages.

  Changes across 5 files:

  **`lib/mixin/batch_select.dart`** *(new)*
  - `BatchSelectMixin` — reusable state machine: `isSelecting`, `selectedCids`, `isDownloading`, `enterSelectionMode`, `toggleItem`, `selectAll`, `invertSelection`, `batchDownload`
  - `batchDownload` concurrently calls `fetchChapters` for each selected comic and submits `ComicDownloadTask` to
  `BackgroundDownloader`

  **`lib/views/mine/favorites.dart`**
  - Applies `BatchSelectMixin`; all selection/download logic removed from the file itself
  - AppBar split into `_SelectionAppBar` / `_NormalAppBar` — two focused widgets instead of one conditional block
  - Bottom `FilledButton` shows "批量下载(N)" when items are selected; disabled during download
  - Page/sort change clears selection; sort menu and page selector disabled during download

  **`lib/views/comics/common_tmi_list.dart`**
  - Added `selectedCids` and `onItemLongPress` params
  - Gesture wrapping centralised here: wraps each item in a `GestureDetector` when `onItemLongPress` is provided; passes
  `enableDefaultGestures: false` to `ContextMenuRegion` to prevent gesture arena conflict; right-click still shows context menu via
  `onSecondaryTapUp`
  - In selection mode, tap routes to `onItemSelected` instead of navigation

  **`lib/views/comics/list_item.dart`** / **`simple_list_item.dart`**
  - Added `isSelected` (highlight decoration) and `isSelecting` (tap behaviour)
  - No gesture logic — kept as pure render widgets

  ## Type of change

  - :x: Bug fix
  - :white_check_mark: New feature / Enhancement — long-press multi-select and batch download for online favorites
  - :x: Breaking change
  - :white_check_mark: Refactor — `BatchSelectMixin`, `_SelectionAppBar`/`_NormalAppBar` split, gesture logic centralised in
  `CommonTMIList`
  - :x: Performance
  - :x: Style
  - :x: Docs
  - :x: Chore