### PR TITLE
feat(reader): add 'view original' button for local comics

### DIFF
--- a/lib/views/reader/widgets/app_bar.dart
+++ b/lib/views/reader/widgets/app_bar.dart
@@ -5,6 +5,7 @@ import 'package:haka_comic/utils/extension.dart';
 import 'package:haka_comic/utils/ui.dart';
 import 'package:haka_comic/views/reader/providers/list_state_provider.dart';
 import 'package:haka_comic/views/reader/providers/reader_provider.dart';
+import 'package:haka_comic/views/reader/state/comic_state.dart';
 import 'package:haka_comic/views/reader/state/read_mode.dart';
 import 'package:haka_comic/views/reader/widgets/reader_settings.dart';
 import 'package:haka_comic/widgets/with_blur.dart';
@@ -47,6 +48,10 @@ class ReaderAppBar extends StatelessWidget {
 
     final readMode = context.selector((p) => p.readMode);
 
+    final readerType = context.selector((p) => p.type);
+
+    final comicId = context.selector((p) => p.id);
+
     final title = context.selector((p) => p.title);
 
     final isSmoothScroll = context.selector((p) => p.isSmoothScroll);
@@ -72,6 +77,12 @@ class ReaderAppBar extends StatelessWidget {
             actions: isSmoothScroll
                 ? null
                 : [
+                    if (readerType == ReaderType.local)
+                      IconButton(
+                        icon: const Icon(Icons.open_in_new),
+                        tooltip: '查看原作品',
+                        onPressed: () => context.push('/details/$comicId'),
+                      ),
                     Builder(
                       builder: (context) {
                         return IconButton(


### PR DESCRIPTION
## Description

Add a "view original" button to the reader AppBar when reading downloaded (local) comics, allowing users to navigate back to the online comic detail page.

Closes #119

## Reasoning

Users who download many comics have no way to navigate back to the original comic's online detail page from the reader. This adds a single conditional button that only appears for local comics (`ReaderType.local`), keeping the reader clean for online and imported comics.

Key design decisions:
- **Minimal invasion**: 1 file changed, 11 lines added, zero modifications to existing logic
- **Consistent patterns**: Uses `context.selector` matching existing AppBar field access style
- **Correct ID chain**: `DownloadComic.id` is the same value passed from `ComicDetails.comicId` at download time, so `/details/$comicId` routes correctly

## Changes

Modified files (1):
- `app_bar.dart` — Add `comic_state.dart` import, read `type`/`id` from provider, conditionally render `IconButton` with `Icons.open_in_new` for `ReaderType.local`

## Type of change

- [ ] Bug fix
- [x] New feature / Enhancement
- [ ] Breaking change
- [ ] Refactor
- [ ] Performance
- [ ] Style
- [ ] Docs
- [ ] Chore