### PR TITLE
feat(reader): add toggle for chapter swipe gesture in vertical mode

### DIFF
--- a/lib/config/app_config.dart
+++ b/lib/config/app_config.dart
@@ -107,6 +107,9 @@ class AppConf {
   /// 预加载的图片数量
   int _preloadImageCount = 4;
 
+  /// 是否启用条漫模式下的滑动切章手势
+  bool _enableChapterSwipe = false;
+
   bool get isLogged => _token.isNotEmpty;
   bool get hasAccount => _email.isNotEmpty && _password.isNotEmpty;
 
@@ -163,6 +166,8 @@ class AppConf {
         prefsWithCache.getBool('enablePageAnimation') ?? true;
     instance._preloadImageCount =
         prefsWithCache.getInt('preloadImageCount') ?? 4;
+    instance._enableChapterSwipe =
+        prefsWithCache.getBool('enableChapterSwipe') ?? false;
   }
 
   set email(String value) {
@@ -360,6 +365,11 @@ class AppConf {
     SharedPreferencesUtil.prefsWithCache.setInt('preloadImageCount', value);
   }
 
+  set enableChapterSwipe(bool value) {
+    _enableChapterSwipe = value;
+    SharedPreferencesUtil.prefsWithCache.setBool('enableChapterSwipe', value);
+  }
+
   String get email => _email;
   String get password => _password;
   String get token => _token;
@@ -397,6 +407,7 @@ class AppConf {
   bool get enableGesture => _enableGesture;
   bool get enablePageAnimation => _enablePageAnimation;
   int get preloadImageCount => _preloadImageCount;
+  bool get enableChapterSwipe => _enableChapterSwipe;
 
   /// 清除token
   void clearAuth() {

--- a/lib/views/reader/providers/list_state_provider.dart
+++ b/lib/views/reader/providers/list_state_provider.dart
@@ -53,4 +53,14 @@ class ListStateProvider extends ChangeNotifier {
     AppConf().showPageNumbers = _showPageNumbers;
     notifyListeners();
   }
+
+  /// 条漫模式下的滑动切章手势开关
+  bool _enableChapterSwipe = AppConf().enableChapterSwipe;
+  bool get enableChapterSwipe => _enableChapterSwipe;
+  void toggleEnableChapterSwipe() {
+    _enableChapterSwipe = !_enableChapterSwipe;
+    AppConf().enableChapterSwipe = _enableChapterSwipe;
+    notifyListeners();
+    Toast.show(message: _enableChapterSwipe ? '滑动切章已开启' : '滑动切章已关闭');
+  }
 }

--- a/lib/views/reader/widgets/bottom.dart
+++ b/lib/views/reader/widgets/bottom.dart
@@ -149,6 +149,23 @@ class _ReaderBottomState extends State<ReaderBottom>
                   tooltip: '平滑滚动',
                   icon: const Icon(Icons.keyboard_double_arrow_down),
                 ),
+              if (context.selector((p) => p.readMode.isVertical))
+                Builder(
+                  builder: (context) {
+                    final enabled = context.stateSelector(
+                      (p) => p.enableChapterSwipe,
+                    );
+                    return IconButton(
+                      onPressed: () {
+                        context.stateReader.toggleEnableChapterSwipe();
+                      },
+                      tooltip: '滑动切章',
+                      icon: Icon(
+                        enabled ? Icons.swipe : Icons.swipe_outlined,
+                      ),
+                    );
+                  },
+                ),
               IconButton(
                 onPressed: () {
                   context.stateReader.toggleLockMenu();

--- a/lib/views/reader/widgets/vertical_list/chapter_swipe_detector.dart
+++ b/lib/views/reader/widgets/vertical_list/chapter_swipe_detector.dart
@@ -102,6 +102,9 @@ class _ChapterSwipeDetectorState extends State<ChapterSwipeDetector> {
 
   @override
   Widget build(BuildContext context) {
+    final enabled = context.stateSelector((p) => p.enableChapterSwipe);
+    if (!enabled) return widget.child;
+
     final isFirst = context.selector<bool>((p) => p.isFirstChapter);
     final isLast = context.selector<bool>((p) => p.isLastChapter);
     final screenW = MediaQuery.sizeOf(context).width;


### PR DESCRIPTION
## Description

Add a toolbar toggle to enable/disable the edge-swipe chapter navigation in vertical (webtoon) reading mode.

Closes #129

## Reasoning

Issue #129 reports that the current edge-swipe chapter jump is too easy to trigger accidentally while reading. The underlying UX (threshold tuning, visual feedback) will be reworked in a follow-up PR; this PR is a minimal stop-gap that lets users opt out immediately.

Key design decisions:
- **Default off**: preserve "do no harm" over backward-compat — users complaining about misfire get relief on upgrade; power users can re-enable from the toolbar
- **Toolbar icon toggle** (not a settings-page switch): users most likely want to flip this mid-reading, not dig into settings; placed next to the existing "平滑滚动" icon
- **Vertical mode only**: the gesture itself only applies in vertical reading mode, so the toggle is hidden otherwise
- **Dual-icon state feedback**: `Icons.swipe` (on) / `Icons.swipe_outlined` (off) — matches the repo's existing ternary-icon pattern (e.g. `favorite`/`favorite_border`)

## Changes

Modified files (4):
- `app_config.dart` — new persisted `enableChapterSwipe` bool (default `false`)
- `list_state_provider.dart` — `toggleEnableChapterSwipe()` with Toast feedback
- `bottom.dart` — new `IconButton` in vertical-mode toolbar
- `chapter_swipe_detector.dart` — bail out early when disabled, skipping all edge listeners

## Type of change

- [ ] Bug fix
- [x] New feature / Enhancement
- [ ] Breaking change
- [ ] Refactor
- [ ] Performance
- [ ] Style
- [ ] Docs
- [ ] Chore